### PR TITLE
Error in box/beanplot is no longer fatal for run_qc.pl

### DIFF
--- a/src/perl/bin/plate_heatmap_plots.pl
+++ b/src/perl/bin/plate_heatmap_plots.pl
@@ -70,7 +70,7 @@ sub makePlots {
     # assume file names are of the form PREFIX_PLATE.txt
     # execute given script with input table, output path, and plate name as arguments
     # supply global min/max as arguments (not used except by XYdiff)
-    my ($inputDir, $plotScript, $expr, $prefix, $minMaxArgs, $test) = @_;
+    my ($inputDir, $plotScript, $expr, $prefix, $minMaxArgs) = @_;
     my @paths = glob($inputDir.'/'.$expr);
     my $allPlotsOK = 1;
     foreach my $path (@paths) {
@@ -86,7 +86,7 @@ sub makePlots {
 	my @args = ($plotScript, $path, $plate);
 	if ($minMaxArgs) { push(@args, ($comments{'PLOT_MIN'}, $comments{'PLOT_MAX'})); }
 	my @outputs = ($outPath, );
-	my $plotsOK = WTSI::Genotyping::QC::QCPlotTests::wrapPlotCommand(\@args, \@outputs, $test);
+	my $plotsOK = WTSI::Genotyping::QC::QCPlotTests::wrapPlotCommand(\@args, \@outputs);
 	if ($plotsOK==0) { $allPlotsOK = 0; }
     } 
     return $allPlotsOK;

--- a/src/perl/bin/plot_cr_het_density.pl
+++ b/src/perl/bin/plot_cr_het_density.pl
@@ -100,7 +100,6 @@ sub writeTable {
 sub run {
     my $title = shift;
     my $outDir = shift;
-    my $test = shift;
     my @names = ('crHetDensityHeatmap.txt', 'crHetDensityHeatmap.png', 'crHet.txt', 
 		 'crHetDensityScatter.png', 'crHistogram.png', 'hetHistogram.png');
     my @paths = ();
@@ -118,7 +117,7 @@ sub run {
     close $output;
     @args = ($heatPlotScript, $heatText, $title, $hetMin, $hetMax);
     @outputs = ($heatPng,);
-    my $plotsOK = WTSI::Genotyping::QC::QCPlotTests::wrapPlotCommand(\@args, \@outputs, $test);
+    my $plotsOK = WTSI::Genotyping::QC::QCPlotTests::wrapPlotCommand(\@args, \@outputs);
     ### do scatterplot & histograms ###
     if ($plotsOK) {
 	open $output, "> $scatterText" || die "Cannot open output path $scatterText: $!";
@@ -127,7 +126,7 @@ sub run {
 	my $scatterPlotScript = "plotCrHetDensity.R";
 	@args = ($scatterPlotScript, $scatterText, $title);
 	@outputs = ($scatterPng, $crHist, $hetHist);
-	$plotsOK = WTSI::Genotyping::QC::QCPlotTests::wrapPlotCommand(\@args, \@outputs, $test);
+	$plotsOK = WTSI::Genotyping::QC::QCPlotTests::wrapPlotCommand(\@args, \@outputs);
     }
     return $plotsOK;    
 }


### PR DESCRIPTION
Instead of dying on box/beanplot error, use log4perl to record an error message.  Beanplot may fail on "sparse" data which is otherwise well-behaved.
