### PR TITLE
removed hardcoded default lsf queue to activate setting the default queu...

### DIFF
--- a/src/ruby/genotyping-workflows/lib/genotyping/workflows/fetch_sample_data.rb
+++ b/src/ruby/genotyping-workflows/lib/genotyping/workflows/fetch_sample_data.rb
@@ -73,8 +73,7 @@ Returns:
       args[:work_dir] = maybe_work_dir(work_dir)
       manifest = args.delete(:manifest) # TODO: find manifest automatically
 
-      async_defaults = {:memory => 500,
-                        :queue => :normal}
+      async_defaults = {:memory => 500}
       async = lsf_args(args, async_defaults, :memory, :queue)
 
       sjname = run_name + '.sample.json'

--- a/src/ruby/genotyping-workflows/lib/genotyping/workflows/genotype_genosnp.rb
+++ b/src/ruby/genotyping-workflows/lib/genotyping/workflows/genotype_genosnp.rb
@@ -77,8 +77,7 @@ Returns:
       args = ensure_valid_args(args, :config, :manifest, :queue, :memory,
                                :chunk_size)
 
-      async_defaults = {:memory => 1024,
-                        :queue => :normal}
+      async_defaults = {:memory => 1024}
       async = lsf_args(args, async_defaults, :memory, :queue)
 
       manifest = args.delete(:manifest) # TODO: find manifest automatically

--- a/src/ruby/genotyping-workflows/lib/genotyping/workflows/genotype_illuminus.rb
+++ b/src/ruby/genotyping-workflows/lib/genotyping/workflows/genotype_illuminus.rb
@@ -80,8 +80,7 @@ Returns:
       args = ensure_valid_args(args, :config, :manifest, :queue, :memory,
                                :chunk_size, :gender_method)
 
-      async_defaults = {:memory => 1024,
-                        :queue => :normal}
+      async_defaults = {:memory => 1024}
       async = lsf_args(args, async_defaults, :memory, :queue)
 
       manifest = args.delete(:manifest) # TODO: find manifest automatically

--- a/src/ruby/genotyping-workflows/test/test_workflows.rb
+++ b/src/ruby/genotyping-workflows/test/test_workflows.rb
@@ -77,10 +77,8 @@ class TestWorkflows < Test::Unit::TestCase
 
       FileUtils.copy(File.join(data_path, 'genotyping.db'), dbfile)
       args = [dbfile, run_name, work_dir, {:manifest => manifest,
-                                           # :gender_method => 'Inferred',
                                            :gender_method => 'Supplied',
                                            :chunk_size => 4000,
-                                           :queue => :normal,
                                            :memory => 2048}]
       timeout = 720
       log = 'percolate.log'
@@ -105,7 +103,6 @@ class TestWorkflows < Test::Unit::TestCase
       FileUtils.copy(File.join(data_path, 'genotyping.db'), dbfile)
       args = [dbfile, run_name, work_dir, {:manifest => manifest,
                                            :chunk_size => 2,
-                                           :queue => :normal,
                                            :memory => 2048}]
       timeout = 720
       log = 'percolate.log'


### PR DESCRIPTION
...e inside percolate. Hope later to change percolate to take LSB_DEFAULTQUEUE as default if set to be able to run on clusters with different queue names.
