### PR TITLE
Ruby test updates

### DIFF
--- a/src/ruby/genotyping-workflows/test/README
+++ b/src/ruby/genotyping-workflows/test/README
@@ -1,5 +1,4 @@
-
-To run test workflow tests, the following steps must be performed:
+To run workflow tests, the following steps must be performed:
 
 Installation:
 
@@ -13,6 +12,8 @@ Installation:
 4) The format-shifting utility program genotype-call must be available on the
    PATH.
 
+5) The plinktools package (version >= 0.4.1) must be available on the PATH.
+
 Test data acquisition:
 
 5) A pipeline runtime database named 'genotyping.db' must be created using the
@@ -21,8 +22,17 @@ Test data acquisition:
 
    This file cannot be distributed for reasons of data confidentiality.
 
+6) Expected Plink output from the genotype callers Illuminus, GenoSNP and 
+   ZCall with input from the genotyping.db described in step 5 must be placed 
+   in an "external data" directory.
+
+   These files cannot be distributed for reasons of confidentiality.
+
+7) A .bpm.csv SNP manifest and .egt cluster file, corresponding to the given 
+   genotyping.db described in step 5, must be placed in the external data 
+   directory described in step 6.
+
 Shell environment setup:
 
-6) The environment variable BEADPOOL_MANIFEST must be set to the absolute path
-   of the Infinium BeadPool manifest (.bpm.csv) file corresponding to the data
-   described by the pipeline runtime database created in step 5.
+8) The environment variable GENOTYPE_TEST_DATA must be set to the absolute path
+   of the external data directory described in step 6 6.

--- a/src/ruby/genotyping-workflows/test/test_genosnp_workflow.rb
+++ b/src/ruby/genotyping-workflows/test/test_genosnp_workflow.rb
@@ -41,12 +41,9 @@ class TestWorkflows < Test::Unit::TestCase
     @msg_port = 11300
   end
 
-  def data_path
-    File.expand_path(File.join(File.dirname(__FILE__), '..', 'data'))
-  end
-
   def test_genotype_genosnp
-    manifest = ENV['BEADPOOL_MANIFEST']
+    external_data = ENV['GENOTYPE_TEST_DATA']
+    manifest = manifest_path
     name = 'test_genotype_genosnp'
 
     run_test_if(lambda { genosnp_available? && manifest },
@@ -67,7 +64,7 @@ class TestWorkflows < Test::Unit::TestCase
 
       plink_name = run_name+'.genosnp'
       stem = File.join(work_dir, plink_name)
-      master = File.join('/nfs/gapi/data/genotype/pipeline_test', plink_name)
+      master = File.join(external_data, plink_name)
       equiv = plink_equivalent?(stem, master, run_name, 
                                 {:work_dir => work_dir,
                                  :log_dir => work_dir})

--- a/src/ruby/genotyping-workflows/test/test_genotype_call_tasks.rb
+++ b/src/ruby/genotyping-workflows/test/test_genotype_call_tasks.rb
@@ -46,10 +46,6 @@ class TestGenotypeCallTasks < Test::Unit::TestCase
     Percolate.asynchronizer = SystemAsynchronizer.new
   end
 
-  def data_path
-    File.expand_path(File.join(File.dirname(__FILE__), '..', 'data'))
-  end
-
   def test_mock_study
     run_test_if(method(:genotype_call_available?), "Skipping test_mock_study") do
       work_dir = make_work_dir('test_mock_study', data_path)

--- a/src/ruby/genotyping-workflows/test/test_helper.rb
+++ b/src/ruby/genotyping-workflows/test/test_helper.rb
@@ -24,6 +24,22 @@ module TestHelper
 
   PLINKTOOLS_DIFF = 'plink_diff.py'
 
+  def data_path
+    File.expand_path(File.join(File.dirname(__FILE__), '..', 'data'))
+  end
+
+  def manifest_path
+    if ENV['GENOTYPE_TEST_DATA']
+      Dir.glob(ENV['GENOTYPE_TEST_DATA']+"/*.bpm.csv").first
+    end
+  end
+
+  def egt_path
+    if ENV['GENOTYPE_TEST_DATA']
+      Dir.glob(ENV['GENOTYPE_TEST_DATA']+"/*.egt").first
+    end
+  end
+
   def test_workflow(name, klass, timeout, path, log, args)
     ['in', 'pass', 'fail'].each do |dir|
       root = File.join(path, dir)

--- a/src/ruby/genotyping-workflows/test/test_illuminus_tasks.rb
+++ b/src/ruby/genotyping-workflows/test/test_illuminus_tasks.rb
@@ -48,10 +48,6 @@ class TestIlluminusTasks < Test::Unit::TestCase
         LSFAsynchronizer.new(:job_arrays_dir => data_path)
   end
 
-  def data_path
-    File.expand_path(File.join(File.dirname(__FILE__), '..', 'data'))
-  end
-
   def test_call_from_sim_p
     run_test_if(method(:illuminus_available?), "Skipping test_call_from_sim_p") do
       work_dir = make_work_dir('test_call_from_sim_p', data_path)

--- a/src/ruby/genotyping-workflows/test/test_illuminus_workflow.rb
+++ b/src/ruby/genotyping-workflows/test/test_illuminus_workflow.rb
@@ -41,12 +41,9 @@ class TestIlluminusWorkflow < Test::Unit::TestCase
     @msg_port = 11300
   end
 
-  def data_path
-    File.expand_path(File.join(File.dirname(__FILE__), '..', 'data'))
-  end
-
   def test_genotype_illuminus
-    manifest = ENV['BEADPOOL_MANIFEST']
+    external_data = ENV['GENOTYPE_TEST_DATA']
+    manifest = manifest_path
     name = 'test_genotype_illuminus'
 
     run_test_if((lambda { illuminus_available? && manifest } and method(:plinktools_diff_available?)), "Skipping #{name}") do
@@ -72,7 +69,7 @@ class TestIlluminusWorkflow < Test::Unit::TestCase
 
       plink_name = run_name+'.illuminus'
       stem = File.join(work_dir, plink_name)
-      master = File.join('/nfs/gapi/data/genotype/pipeline_test', plink_name)
+      master = File.join(external_data, plink_name)
       equiv = plink_equivalent?(stem, master, run_name, 
                                 {:work_dir => work_dir,
                                  :log_dir => work_dir})

--- a/src/ruby/genotyping-workflows/test/test_plink_tasks.rb
+++ b/src/ruby/genotyping-workflows/test/test_plink_tasks.rb
@@ -45,10 +45,6 @@ class TestPlinkTasks < Test::Unit::TestCase
     Percolate.asynchronizer = SystemAsynchronizer.new
   end
 
-  def data_path
-    File.expand_path(File.join(File.dirname(__FILE__), '..', 'data'))
-  end
-
   def test_merge_bed
     run_test_if(method(:plink_merge_available?), "Skipping test_merge_bed") do
       work_dir = make_work_dir('test_merge_bed', data_path)

--- a/src/ruby/genotyping-workflows/test/test_simtools_tasks.rb
+++ b/src/ruby/genotyping-workflows/test/test_simtools_tasks.rb
@@ -34,6 +34,7 @@ class TestSimtoolsTasks < Test::Unit::TestCase
   include TestHelper
   include Genotyping
   include Genotyping::Tasks::GenotypeCall # for mock_study
+  include Genotyping::Tasks::Metadata
   include Genotyping::Tasks::Simtools
 
   def initialize(name)
@@ -98,6 +99,49 @@ class TestSimtoolsTasks < Test::Unit::TestCase
       assert(File.exists?(bed_file))
 
       Percolate.log.close
+      remove_work_dir(work_dir)
+    end
+  end
+
+  def test_g2i_normalize
+    # test the normalization side effect of g2i (gtc-to-bed executable)
+    # compare output of g2i with normalized and un-normalized manifests
+    manifest = ENV['BEADPOOL_MANIFEST']
+    name = 'test_g2i_normalize'
+    run_test_if((lambda { g2i_available? && manifest }), "Skipping test_g2i_normalize") do
+      work_dir = make_work_dir(name, data_path)
+      # create normalized and un-normalized copies of manifest
+      manifest_raw = File.join(work_dir, File.basename(manifest))
+      FileUtils.copy(manifest, manifest_raw)
+      manifest_norm = File.join(work_dir, 'manifest_normalized.bpm.csv')
+      args = {:work_dir => work_dir, :log_dir => work_dir}
+      wait_for('normalize_manifest', 60, 5) do
+        normalize_manifest(manifest_raw, manifest_norm, args)
+      end    
+      # generate sample json file from test pipeline DB
+      dbfile = File.join(work_dir, name + '.db')
+      FileUtils.copy(File.join(data_path, 'genotyping.db'), dbfile)
+      run_name = 'run1'
+      sample_json = File.join(work_dir, name+'_sample.json')
+      wait_for('sample_intensities', 60, 5) do
+        sample_intensities(dbfile, run_name, sample_json,
+                           args.merge({:gender_method => "Supplied"}))
+      end
+      # now run gtc_to_bed twice, once with each manifest version
+      prefix_raw = 'not_normalized'
+      prefix_norm = 'normalized'
+      bed_file_raw = wait_for('gtc_to_bed_raw', 60, 5) do
+        gtc_to_bed(sample_json, manifest_raw, prefix_raw+".bed", args)
+      end
+      bed_file_norm = wait_for('gtc_to_bed_norm', 60, 5) do
+        gtc_to_bed(sample_json, manifest_norm, prefix_norm+".bed", args)
+      end
+      # compare outputs
+      for suffix in [".bed", ".bim", ".fam"] do
+        rawfile = File.join(work_dir, prefix_raw+suffix)
+        normfile = File.join(work_dir, prefix_norm+suffix)
+        assert(FileUtils.compare_file(rawfile, normfile))
+      end
       remove_work_dir(work_dir)
     end
   end

--- a/src/ruby/genotyping-workflows/test/test_simtools_tasks.rb
+++ b/src/ruby/genotyping-workflows/test/test_simtools_tasks.rb
@@ -48,10 +48,6 @@ class TestSimtoolsTasks < Test::Unit::TestCase
     Percolate.asynchronizer = SystemAsynchronizer.new
   end
 
-  def data_path
-    File.expand_path(File.join(File.dirname(__FILE__), '..', 'data'))
-  end
-
   def test_gtc_to_sim
     run_test_if(method(:simtools_available?), "Skipping test_gtc_to_sim") do
       work_dir = make_work_dir('test_gtc_to_sim', data_path)
@@ -106,7 +102,7 @@ class TestSimtoolsTasks < Test::Unit::TestCase
   def test_g2i_normalize
     # test the normalization side effect of g2i (gtc-to-bed executable)
     # compare output of g2i with normalized and un-normalized manifests
-    manifest = ENV['BEADPOOL_MANIFEST']
+    manifest = manifest_path
     name = 'test_g2i_normalize'
     run_test_if((lambda { g2i_available? && manifest }), "Skipping test_g2i_normalize") do
       work_dir = make_work_dir(name, data_path)

--- a/src/ruby/genotyping-workflows/test/test_zcall_workflow.rb
+++ b/src/ruby/genotyping-workflows/test/test_zcall_workflow.rb
@@ -16,9 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-##########################################################
-# test ground for development of the zcall workflow
-##########################################################
 
 devpath = File.expand_path(File.join(File.dirname(__FILE__), '..'))
 libpath = File.join(devpath, 'lib')
@@ -45,20 +42,15 @@ class TestWorkflowZCall < Test::Unit::TestCase
     @msg_port = 11300
   end
 
-  def data_path
-    File.expand_path(File.join(File.dirname(__FILE__), '..', 'data'))
-  end
-
   def test_genotype_zcall
-    manifest = ENV['BEADPOOL_MANIFEST']
-    egt_file = ENV['BEADPOOL_EGT']
-    unless egt_file
-      egt_file = '/nfs/gapi/data/genotype/zcall_test/'+
-        'Human670-QuadCustom_v1_A.egt'
-    end
+    
+    external_data = ENV['GENOTYPE_TEST_DATA']
+    manifest = manifest_path
+    egt = egt_path
+
     name = 'test_genotype_zcall'
 
-    run_test_if(lambda { zcall_available? && manifest },
+    run_test_if(lambda { zcall_available? && manifest && egt },
                 "Skipping #{name}") do
       work_dir = make_work_dir(name, data_path)
       dbfile = File.join(work_dir, name + '.db')
@@ -68,7 +60,7 @@ class TestWorkflowZCall < Test::Unit::TestCase
       # Only 1 zscore in range; faster but omits threshold evaluation
       # The evaluation is tested by test_zcall_tasks.rb
       args = [dbfile, run_name, work_dir, {:manifest => manifest,
-                                           :egt => egt_file,
+                                           :egt => egt,
                                            :chunk_size => 3,
                                            :zstart => 6,
                                            :ztotal => 1,
@@ -81,7 +73,7 @@ class TestWorkflowZCall < Test::Unit::TestCase
 
       plink_name = run_name+'.zcall'
       stem = File.join(work_dir, plink_name)
-      master = File.join('/nfs/gapi/data/genotype/pipeline_test', plink_name)
+      master = File.join(external_data, plink_name)
       equiv = plink_equivalent?(stem, master, run_name, 
                                 {:work_dir => work_dir,
                                  :log_dir => work_dir})


### PR DESCRIPTION
- Added 'GENOTYPE_TEST_DATA' environment variable to denote path for non-public test data
- Consolidated multiple, identical data_path functions into one instance in test_helper.rb
- Added test_g2i_normalize to test the manifest normalization "side effect" of g2i
- Moved the zcall_test directory used by test_zcall_tasks.rb into the main GENOTYPE_TEST_DATA directory
