### PR TITLE
Fixes to Ruby workflow tests

### DIFF
--- a/src/ruby/genotyping-workflows/lib/genotyping/workflows/genotype_zcall.rb
+++ b/src/ruby/genotyping-workflows/lib/genotyping/workflows/genotype_zcall.rb
@@ -117,7 +117,7 @@ Returns:
       run_name = run_name.to_s;
       gcsjname = run_name + '.gencall.sample.json'
       gcsimname = run_name + '.gencall.sim'
-      ilsimname = run_name + '.illuminus.sim'
+      zsimname = run_name + '.zcall_qc.sim'
       sjname = run_name + '.sample.json'
       njname = run_name + '.snp.json'
       cjname = run_name + '.chr.json'
@@ -207,11 +207,12 @@ Returns:
       if nosim
         # no sim file, therefore no intensity metrics
         qcargs = {:run => run_name}.merge(args)
-      else
+      elsif nofilter or filtered
+        # if prefilter is switched off, or has successfully completed
         # generate new .sim file to reflect sample exclusions
-        ilsimfile = gtc_to_sim(sjson, manifest, ilsimname, smargs, async)
-        if ilsimfile
-          qcargs = {:run => run_name, :sim => ilsimfile}.merge(args)
+        zsimfile = gtc_to_sim(sjson, manifest, zsimname, smargs, async)
+        if zsimfile
+          qcargs = {:run => run_name, :sim => zsimfile}.merge(args)
         end
       end
       if qcargs

--- a/src/ruby/genotyping-workflows/test/test_genosnp_workflow.rb
+++ b/src/ruby/genotyping-workflows/test/test_genosnp_workflow.rb
@@ -52,7 +52,7 @@ class TestWorkflows < Test::Unit::TestCase
       dbfile = File.join(work_dir, name + '.db')
       run_name = 'run1'
 
-      FileUtils.copy(File.join(data_path, 'genotyping.db'), dbfile)
+      FileUtils.copy(File.join(external_data, 'genotyping.db'), dbfile)
       args = [dbfile, run_name, work_dir, {:manifest => manifest,
                                            :chunk_size => 4,
                                            :memory => 2048}]

--- a/src/ruby/genotyping-workflows/test/test_illuminus_workflow.rb
+++ b/src/ruby/genotyping-workflows/test/test_illuminus_workflow.rb
@@ -52,7 +52,7 @@ class TestIlluminusWorkflow < Test::Unit::TestCase
       run_name = 'run1'
       pipe_ini = File.join(data_path, 'genotyping.ini')
 
-      FileUtils.copy(File.join(data_path, 'genotyping.db'), dbfile)
+      FileUtils.copy(File.join(external_data, 'genotyping.db'), dbfile)
       fconfig = File.join(data_path, 'illuminus_test_prefilter.json')
       args_hash = {:manifest => manifest,
                    :config => pipe_ini,

--- a/src/ruby/genotyping-workflows/test/test_zcall_workflow.rb
+++ b/src/ruby/genotyping-workflows/test/test_zcall_workflow.rb
@@ -56,7 +56,7 @@ class TestWorkflowZCall < Test::Unit::TestCase
       dbfile = File.join(work_dir, name + '.db')
       run_name = 'run1'
 
-      FileUtils.copy(File.join(data_path, 'genotyping.db'), dbfile)
+      FileUtils.copy(File.join(external_data, 'genotyping.db'), dbfile)
       # Only 1 zscore in range; faster but omits threshold evaluation
       # The evaluation is tested by test_zcall_tasks.rb
       args = [dbfile, run_name, work_dir, {:manifest => manifest,


### PR DESCRIPTION
- Change location of genotyping.db to the GENOTYPE_TEST_DATA directory
- Bugfix: Ensure zcall QC sim file is generated after sample filtering
