### PR TITLE
Roll back to last released version of script

### DIFF
--- a/src/perl/bin/check_identity_bed.pl
+++ b/src/perl/bin/check_identity_bed.pl
@@ -5,7 +5,7 @@ use strict;
 use Carp;
 use Cwd;
 use Getopt::Long;
-use WTSI::NPG::Genotyping::QC_wip::Identity;
+use WTSI::NPG::Genotyping::QC::Identity;
 use WTSI::NPG::Genotyping::QC::QCPlotShared qw(readThresholds);
 
 our $DEFAULT_INI = $ENV{HOME} . "/.npg/genotyping.ini";
@@ -101,7 +101,7 @@ $swap ||= $swapDefault;
 
 $iniPath ||= $DEFAULT_INI;
 
-WTSI::NPG::Genotyping::QC_wip::Identity->new(
+WTSI::NPG::Genotyping::QC::Identity->new(
     db_path => $dbPath,
     ini_path => $iniPath,
     min_shared_snps => $minSNPs,


### PR DESCRIPTION
- Use QC::Identity instead of QC_wip::Identity for now, to enable tests to pass.
- QC_wip::Identity will be superseded by QC_wip::Check::Identity.
