### PR TITLE
Ignore the new history AVUs in the tests; these are tested elsewhere

### DIFF
--- a/src/perl/t/WTSI/NPG/Expression/InfiniumDataObjectTest.pm
+++ b/src/perl/t/WTSI/NPG/Expression/InfiniumDataObjectTest.pm
@@ -150,7 +150,8 @@ sub update_secondary_metadata : Test(7) {
      {attribute => 'study_id',                value => '0'},
      {attribute => 'type',                    value => 'idat'}];
 
-  my $idat_meta = $idat_obj->metadata;
+  my $idat_meta = [grep { $_->{attribute} !~ m{_history$} }
+                   @{$idat_obj->metadata}];
   is_deeply($idat_meta, $idat_expected_meta, 'Secondary metadata added 1')
     or diag explain $idat_meta;
 
@@ -175,7 +176,8 @@ sub update_secondary_metadata : Test(7) {
      {attribute => 'study_id',                value => '0'},
      {attribute => 'type',                    value => 'xml'}];
 
-  my $xml_meta = $xml_obj->metadata;
+  my $xml_meta = [grep { $_->{attribute} !~ m{_history$} }
+                  @{$xml_obj->metadata}];
   is_deeply($xml_meta, $xml_expected_meta, 'Secondary metadata added 2')
     or diag explain $xml_meta;
 

--- a/src/perl/t/WTSI/NPG/Genotyping/Fluidigm/AssayDataObjectTest.pm
+++ b/src/perl/t/WTSI/NPG/Genotyping/Fluidigm/AssayDataObjectTest.pm
@@ -138,7 +138,8 @@ sub update_secondary_metadata : Test(4) {
      {attribute => 'sample_supplier_name',    value => 'aaaaaaaaaa'},
      {attribute => 'study_id',                value => '0'}];
 
-  my $meta = $data_object->metadata;
+  my $meta = [grep { $_->{attribute} !~ m{_history$} }
+              @{$data_object->metadata}];
   is_deeply($meta, $expected_meta, 'Secondary metadata added')
     or diag explain $meta;
 

--- a/src/perl/t/WTSI/NPG/Genotyping/Infinium/InfiniumDataObjectTest.pm
+++ b/src/perl/t/WTSI/NPG/Genotyping/Infinium/InfiniumDataObjectTest.pm
@@ -152,7 +152,8 @@ sub update_secondary_metadata : Test(4) {
      {attribute => 'study_id',                value => '0'},
      {attribute => 'type',                    value => 'gtc'}];
 
-  my $meta = $data_object->metadata;
+  my $meta = [grep { $_->{attribute} !~ m{_history$} }
+              @{$data_object->metadata}];
   is_deeply($meta, $expected_meta, 'Secondary metadata superseded')
     or diag explain $meta;
 
@@ -198,7 +199,8 @@ sub update_consent_withdrawn : Test(4) {
      {attribute => 'study_id',                value => '0'},
      {attribute => 'type',                    value => 'gtc'}];
 
-  my $meta = $data_object->metadata;
+  my $meta = [grep { $_->{attribute} !~ m{_history$} }
+              @{$data_object->metadata}];
   is_deeply($meta, $expected_meta, 'Secondary metadata superseded')
     or diag explain $meta;
 

--- a/src/perl/t/WTSI/NPG/Genotyping/Sequenom/AssayDataObjectTest.pm
+++ b/src/perl/t/WTSI/NPG/Genotyping/Sequenom/AssayDataObjectTest.pm
@@ -184,7 +184,8 @@ sub update_secondary_metadata : Test(4) {
      {attribute => 'sequenom_well',           value => 'A10'},
      {attribute => 'study_id',                value => '0'}];
 
-  my $meta = $data_object->metadata;
+  my $meta =  [grep { $_->{attribute} !~ m{_history$} }
+               @{$data_object->metadata}];
   is_deeply($meta, $expected_meta, 'Secondary metadata superseded')
     or diag explain $meta;
 


### PR DESCRIPTION
These are tested elsewhere (in perl-irods-wrap).