### PR TITLE
Improved metadata update robustness

### DIFF
--- a/src/perl/t/WTSI/NPG/Genotyping/Infinium/InfiniumDataObjectTest.pm
+++ b/src/perl/t/WTSI/NPG/Genotyping/Infinium/InfiniumDataObjectTest.pm
@@ -9,6 +9,12 @@ use utf8;
 
   extends 'WTSI::NPG::Database';
 
+  has 'test_sanger_sample_id' =>
+    (is       => 'rw',
+     isa      => 'Str | Undef',
+     required => 0,
+     default  => sub { '0123456789' });
+
   has 'test_consent_withdrawn' =>
     (is       => 'rw',
      isa      => 'Int',
@@ -22,7 +28,7 @@ use utf8;
        confess "WarehouseStub expected map argument 'A10' but got '$map'";
 
     return {internal_id        => 123456789,
-            sanger_sample_id   => '0123456789',
+            sanger_sample_id   => $self->test_sanger_sample_id,
             consent_withdrawn  => $self->test_consent_withdrawn,
             donor_id           => 'D999',
             uuid               => 'AAAAAAAAAABBBBBBBBBBCCCCCCCCCCDD',
@@ -55,7 +61,7 @@ use warnings;
 use base qw(Test::Class);
 use File::Spec;
 use List::AllUtils qw(none);
-use Test::More tests => 13;
+use Test::More tests => 15;
 use Test::Exception;
 
 use WTSI::NPG::iRODS;
@@ -162,6 +168,48 @@ sub update_secondary_metadata : Test(4) {
 
   is_deeply(\@groups_after, $expected_groups_after, 'Groups after update')
     or diag explain \@groups_after;
+}
+
+sub update_secondary_metadata_missing_value : Test(2) {
+  my $irods = WTSI::NPG::iRODS->new;
+
+  my $gtc_irods_path = "$irods_tmp_coll/$gtc_file";
+  my $data_object = WTSI::NPG::Genotyping::Infinium::InfiniumDataObject->new
+    ($irods, $gtc_irods_path);
+
+  my $ssdb = WTSI::NPG::Database::WarehouseStub->new
+    (name    => 'sequencescape_warehouse',
+     inifile => File::Spec->catfile($ENV{HOME}, '.npg/genotyping.ini'),
+     test_sanger_sample_id => q{});
+
+  ok($data_object->update_secondary_metadata($ssdb));
+
+  # The (empty) sanger_sample_id gets mapped to dcterms:identifier in
+  # the metadata. The attributes are superseded in lexical sort order,
+  # so this one is done first. The test ensures that an invalid AVU
+  # value only causes that AVU to be skipped - all subsequent ones are
+  # applied.
+  my $expected_meta =
+    [# {attribute => 'dcterms:identifier',      value => '0123456789'},
+     {attribute => 'infinium_plate',          value => 'plate1'},
+     {attribute => 'infinium_well',           value => 'A10'},
+     {attribute => 'sample',                  value => 'sample1' },
+     {attribute => 'sample_accession_number', value => 'A0123456789'},
+     {attribute => 'sample_cohort',           value => 'AAA111222333'},
+     {attribute => 'sample_common_name',      value => 'Homo sapiens'},
+     {attribute => 'sample_consent',          value => '1'},
+     {attribute => 'sample_control',          value => 'XXXYYYZZZ'},
+     {attribute => 'sample_donor_id',         value => 'D999'},
+     {attribute => 'sample_id',               value => '123456789'},
+     {attribute => 'sample_supplier_name',    value => 'aaaaaaaaaa'},
+     {attribute => 'study_id',                value => '0'},
+     {attribute => 'type',                    value => 'gtc'}];
+
+  my $meta = [grep { $_->{attribute} !~ m{_history$} }
+              @{$data_object->metadata}];
+  is_deeply($meta, $expected_meta,
+            'Secondary metadata addition skips bad value')
+    or diag explain $meta;
 }
 
 sub update_consent_withdrawn : Test(4) {

--- a/src/perl/t/WTSI/NPG/Genotyping/Sequenom/AssayDataObjectTest.pm
+++ b/src/perl/t/WTSI/NPG/Genotyping/Sequenom/AssayDataObjectTest.pm
@@ -45,6 +45,12 @@ use utf8;
 
   extends 'WTSI::NPG::Database';
 
+  has 'test_sanger_sample_id' =>
+    (is       => 'rw',
+     isa      => 'Str | Undef',
+     required => 0,
+     default  => sub { '0123456789' });
+
   Log::Log4perl::init('./etc/log4perl_tests.conf');
 
   sub find_sample_by_plate {
@@ -56,7 +62,7 @@ use utf8;
       confess "WarehouseStub expected map argument 'A10' but got '$map'";
 
     return {internal_id        => 123456789,
-            sanger_sample_id   => '0123456789',
+            sanger_sample_id   => $self->test_sanger_sample_id,
             consent_withdrawn  => 0,
             donor_id           => 'D999',
             uuid               => 'AAAAAAAAAABBBBBBBBBBCCCCCCCCCCDD',
@@ -88,7 +94,7 @@ use warnings;
 
 use base qw(Test::Class);
 use File::Spec;
-use Test::More tests => 15;
+use Test::More tests => 17;
 use Test::Exception;
 
 use WTSI::NPG::iRODS;
@@ -194,6 +200,50 @@ sub update_secondary_metadata : Test(4) {
 
   is_deeply(\@groups_after, $expected_groups_after, 'Groups after update')
     or diag explain \@groups_after;
+}
+
+sub update_secondary_metadata_missing_value : Test(2) {
+  my $irods = WTSI::NPG::iRODS->new;
+
+  my $data_object = WTSI::NPG::Genotyping::Sequenom::AssayDataObject->new
+    ($irods, "$irods_tmp_coll/$data_file");
+
+  my $snpdb = WTSI::NPG::Genotyping::Database::SNPStub->new
+    (name => 'snp',
+     inifile => File::Spec->catfile($ENV{HOME}, '.npg/genotyping.ini'));
+
+  my $ssdb = WTSI::NPG::Database::WarehouseStub->new
+    (name => 'sequencescape_warehouse',
+     inifile => File::Spec->catfile($ENV{HOME}, '.npg/genotyping.ini'),
+     test_sanger_sample_id => q{});
+
+  ok($data_object->update_secondary_metadata($snpdb, $ssdb));
+
+  # The (empty) sanger_sample_id gets mapped to dcterms:identifier in
+  # the metadata. The attributes are superseded in lexical sort order,
+  # so this one is done first. The test ensures that an invalid AVU
+  # value only causes that AVU to be skipped - all subsequent ones are
+  # applied.
+  my $expected_meta =
+    [# attribute => 'dcterms:identifier',      value => '0123456789'},
+     {attribute => 'sample',                  value => 'sample1' },
+     {attribute => 'sample_accession_number', value => 'A0123456789'},
+     {attribute => 'sample_cohort',           value => 'AAA111222333'},
+     {attribute => 'sample_common_name',      value => 'Homo sapiens'},
+     {attribute => 'sample_consent',          value => '1'},
+     {attribute => 'sample_control',          value => 'XXXYYYZZZ'},
+     {attribute => 'sample_donor_id',         value => 'D999'},
+     {attribute => 'sample_id',               value => '123456789'},
+     {attribute => 'sample_supplier_name',    value => 'aaaaaaaaaa'},
+     {attribute => 'sequenom_plate',          value => 'plate1'},
+     {attribute => 'sequenom_well',           value => 'A10'},
+     {attribute => 'study_id',                value => '0'}];
+
+  my $meta =  [grep { $_->{attribute} !~ m{_history$} }
+               @{$data_object->metadata}];
+  is_deeply($meta, $expected_meta,
+            'Secondary metadata addition skips bad value')
+    or diag explain $meta;
 }
 
 sub update_qc_metadata : Test(7) {


### PR DESCRIPTION
Added try/catch around adding each metadata AVU for Fluidigm (also Sequenom, Infinium). Ensures that all are attempted, despite any bad inputs.