### PR TITLE
Merge changes from iainrb/vcf_read_write and fix conflicts

### DIFF
--- a/src/perl/MANIFEST
+++ b/src/perl/MANIFEST
@@ -358,6 +358,7 @@ t/gender/input_xhet.json
 t/gender/input_xhet.txt
 t/gender/input_xhet_large.txt
 t/gender_marker.t
+t/gender_marker_call.t
 t/gender_standalone.t
 t/genotyping_yml.t
 t/genotyping_yml/config.yml
@@ -651,6 +652,7 @@ t/WTSI/NPG/Genotyping/Fluidigm/ExportFileTest.pm
 t/WTSI/NPG/Genotyping/Fluidigm/PublisherTest.pm
 t/WTSI/NPG/Genotyping/Fluidigm/ResultSetTest.pm
 t/WTSI/NPG/Genotyping/Fluidigm/SubscriberTest.pm
+t/WTSI/NPG/Genotyping/GenderMarkerCallTest.pm
 t/WTSI/NPG/Genotyping/GenderMarkerTest.pm
 t/WTSI/NPG/Genotyping/IlluminusTest.pm
 t/WTSI/NPG/Genotyping/Infinium/AnalysisPublisherTest.pm

--- a/src/perl/bin/vcf_consistency_check.pl
+++ b/src/perl/bin/vcf_consistency_check.pl
@@ -38,10 +38,11 @@ my $embedded_conf = "
 ";
 
 
-my ($input, $jsonOut, $log, $logConfig, $textOut, $verbose);
+my ($input, $debug, $jsonOut, $log, $logConfig, $textOut, $verbose);
 
 GetOptions('help'        => sub { pod2usage(-verbose => 2,
                                             -exitval => 0) },
+           'debug'     => \$debug,
            'input=s'     => \$input,
            'json=s'      => \$jsonOut,
            'logconf=s'   => \$logConfig,
@@ -51,10 +52,18 @@ GetOptions('help'        => sub { pod2usage(-verbose => 2,
 
 
 ### set up logging ###
-if ($logConfig) { Log::Log4perl::init($logConfig); }
-else { Log::Log4perl::init(\$embedded_conf); }
+if ($logConfig) {
+    Log::Log4perl::init($logConfig);
+} else {
+    Log::Log4perl::init(\$embedded_conf);
+}
 $log = Log::Log4perl->get_logger('npg.vcf.consistency');
-
+if ($verbose) {
+    $log->level($INFO);
+}
+elsif ($debug) {
+    $log->level($DEBUG);
+}
 
 ### read input and do consistency check
 

--- a/src/perl/bin/vcf_from_plex.pl
+++ b/src/perl/bin/vcf_from_plex.pl
@@ -41,8 +41,7 @@ my $embedded_conf = "
 ";
 
 
-my ($input, $inputType, $vcfPath, $gtCheck,
-    $log, $logConfig, $use_irods, $debug, $quiet,
+my ($input, $inputType, $vcfPath, $log, $logConfig, $use_irods, $debug, $quiet,
     $snpset_path, $chromosome_json);
 
 my $CHROMOSOME_JSON_KEY = 'chromosome_json';

--- a/src/perl/lib/WTSI/NPG/Genotyping/Call.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Call.pm
@@ -28,7 +28,7 @@ has 'is_call' =>
 
 has 'qscore' =>
   (is      => 'ro',
-   isa     => 'Num');
+   isa     => QualityScore);
 
 sub BUILD {
   my ($self) = @_;
@@ -130,7 +130,7 @@ sub is_homozygous_complement {
 
   my $rr = $r . $r;
   my $aa = $a . $a;
-  my $cgt = _complement($self->genotype);
+  my $cgt = $self->_complement($self->genotype);
 
   return $cgt eq $rr || $cgt eq $aa;
 }
@@ -155,7 +155,7 @@ sub is_heterozygous_complement {
 
   my $ra = $r . $a;
   my $ar = $a . $r;
-  my $cgt = _complement($self->genotype);
+  my $cgt = $self->_complement($self->genotype);
 
   return $cgt eq $ra || $cgt eq $ar;
 }
@@ -181,7 +181,7 @@ sub is_complement {
   my $aa = $a . $a; # Homozygous alt
   my $ra = $r . $a; # Heterozygous
   my $ar = $a . $r; # Heterozygous
-  my $cgt = _complement($self->genotype);
+  my $cgt = $self->_complement($self->genotype);
 
   return $cgt eq $rr || $cgt eq $aa || $cgt eq $ra || $cgt eq $ar;
 }
@@ -202,13 +202,13 @@ sub complement {
   if (defined($self->qscore)) {
       return WTSI::NPG::Genotyping::Call->new
           (snp      => $self->snp,
-           genotype => _complement($self->genotype),
+           genotype => $self->_complement($self->genotype),
            qscore   => $self->qscore,
            is_call  => $self->is_call);
   } else {
       return WTSI::NPG::Genotyping::Call->new
           (snp      => $self->snp,
-           genotype => _complement($self->genotype),
+           genotype => $self->_complement($self->genotype),
            is_call  => $self->is_call);
   }
 }
@@ -275,6 +275,9 @@ sub equivalent {
   $self->snp->equals($other->snp) or
     $self->logconfess("Attempted to compare calls for non-identical SNPs: ",
                       $self->snp->name, " and ", $other->snp->name);
+  # If $self is a GenderMarkerCall, $self->snp->equals will use the equals()
+  # method of the GenderMarker class. So two GenderMarkerCalls are equal
+  # iff their GenderMarker attributes are equal.
 
   my $equivalent = 0;
 
@@ -330,7 +333,7 @@ sub str {
 }
 
 sub _complement {
-  my ($genotype) = @_;
+  my ($self, $genotype) = @_;
 
   $genotype =~ tr/ACGTNacgtn/TGCANtgcan/;
   return $genotype;

--- a/src/perl/lib/WTSI/NPG/Genotyping/Call.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Call.pm
@@ -21,14 +21,17 @@ has 'genotype' =>
    isa      => SNPGenotype,
    required => 1);
 
-has 'is_call' =>
-  (is       => 'rw',
-   isa      => 'Bool',
-   default  => 1); # used to represent 'no calls'
+has 'is_call'    =>
+  (is            => 'rw',
+   isa           => 'Bool',
+   default       => 1,
+   documentation => "used to represent 'no calls'");
 
-has 'qscore' =>
-  (is      => 'ro',
-   isa     => QualityScore);
+has 'qscore'     =>
+  (is            => 'ro',
+   isa           => 'Maybe['.QualityScore.']',
+   documentation => "May be a Phred quality score (positive integer),".
+       " or undef if the score is missing or not defined");
 
 sub BUILD {
   my ($self) = @_;

--- a/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/AssayResult.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/AssayResult.pm
@@ -239,28 +239,27 @@ sub sample_address {
   return $sample_address;
 }
 
-=head2 quality_score
+=head2 qscore
 
   Arg [1]    : None
 
-  Example    : $qscore = $result->quality_score
+  Example    : $q = $result->qscore()
   Description: Return the Phred-scaled quality score from the Fluidigm result.
                Fluidigm has a percentage quality score, eg. 99.99.
                Convert this to Phred: -10 * log10(Pr(error))
                Round to nearest integer
-  Returntype : Num
+
+  Returntype : QualityScore
 
 =cut
 
-sub quality_score {
+sub qscore {
     my ($self) = @_;
     my $pr_error = 1 - ($self->confidence / 100);
     my $qscore = -10 * log10($pr_error);
     $qscore = int($qscore + 0.5); # initial qscore is guaranteed non-negative
     return $qscore;
 }
-
-
 
 sub _parse_assay {
   # Parse the 'assay' field and return the assay identifier. Field
@@ -295,11 +294,11 @@ one sample.
 
 =head1 AUTHOR
 
-Keith James <kdj@sanger.ac.uk>
+Keith James <kdj@sanger.ac.uk>, Iain Bancarz <ib5@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (c) 2014, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/GenderMarkerCall.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/GenderMarkerCall.pm
@@ -9,6 +9,12 @@ extends 'WTSI::NPG::Genotyping::Call';
 
 use WTSI::NPG::Genotyping::Types qw(:all);
 
+our $VERSION = '';
+
+our $UNKNOWN_GENDER = 0;
+our $FEMALE_GENDER = 1;
+our $MALE_GENDER = 2;
+
 with 'WTSI::DNAP::Utilities::Loggable';
 
 has 'snp' =>
@@ -21,10 +27,6 @@ has 'gender' =>
      isa     => 'Int',
      lazy    => 1,
      builder => '_build_gender');
-
-our $UNKNOWN_GENDER = 0;
-our $FEMALE_GENDER = 1;
-our $MALE_GENDER = 2;
 
 sub BUILD {
   my ($self) = @_;
@@ -131,6 +133,12 @@ sub _build_gender {
     return $gender;
 }
 
+
+__PACKAGE__->meta->make_immutable;
+
+no Moose;
+
+1;
 
 __END__
 

--- a/src/perl/lib/WTSI/NPG/Genotyping/GenderMarkerCall.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/GenderMarkerCall.pm
@@ -26,6 +26,42 @@ our $UNKNOWN_GENDER = 0;
 our $FEMALE_GENDER = 1;
 our $MALE_GENDER = 2;
 
+sub BUILD {
+  my ($self) = @_;
+  if ($self->is_heterozygous()) {
+      $self->logcroak("Gender marker cannot have a heterozygous genotype!");
+  }
+}
+
+=head2 complement
+
+  Arg [1]    : None
+
+  Example    : my $new_gm_call = $gm_call->complement
+  Description: Return a new call object whose genotype is complemented
+               with respect to the original, retaining qscore (if any).
+               Overrides method in the parent class to return a
+               GenderMarkerCall.
+  Returntype : WTSI::NPG::Genotyping::GenderMarkerCall
+
+=cut
+
+sub complement {
+  my ($self) = @_;
+  my $complement_genotype = $self->_complement($self->genotype);
+  if (defined($self->qscore)) {
+      return WTSI::NPG::Genotyping::GenderMarkerCall->new
+          (snp      => $self->snp,
+           genotype => $self->_complement($self->genotype),
+           qscore   => $self->qscore,
+           is_call  => $self->is_call);
+  } else {
+      return WTSI::NPG::Genotyping::GenderMarkerCall->new
+          (snp      => $self->snp,
+           genotype => $self->_complement($self->genotype),
+           is_call  => $self->is_call);
+  }
+}
 
 =head2 is_x_call
 

--- a/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/AssayResult.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/AssayResult.pm
@@ -107,7 +107,7 @@ sub canonical_sample_id {
 
 sub qscore {
     my ($self) = @_;
-    return undef;
+    return;
 }
 
 

--- a/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/AssayResult.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/AssayResult.pm
@@ -93,22 +93,21 @@ sub canonical_sample_id {
 }
 
 
-=head2 quality_score
+=head2 qscore
 
   Arg [1]    : None
 
-  Example    : $boolean = $result->has_quality_score
+  Example    : $q = $result->qscore()
   Description: Placeholder. In the Fluidigm::AssayResult class, the function
                of this name returns a Phred-scaled quality score. This
-               function returns -1 to indicate 'no score' (since Phred
-               scores by definition are non-negative).
-  Returntype : Str
+               function always returns undef.
+  Returntype : QualityScore
 
 =cut
 
-sub quality_score {
+sub qscore {
     my ($self) = @_;
-    return -1;
+    return undef;
 }
 
 
@@ -201,11 +200,11 @@ one sample.
 
 =head1 AUTHOR
 
-Keith James <kdj@sanger.ac.uk>
+Keith James <kdj@sanger.ac.uk>, Iain Bancarz <ib5@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (c) 2014, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/Types.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Types.pm
@@ -3,10 +3,10 @@ use utf8;
 
 package WTSI::NPG::Genotyping::Types;
 
+use MooseX::Types::Moose qw(ArrayRef Str Int Maybe);
 use strict;
 use warnings;
 
-use MooseX::Types::Moose qw(ArrayRef Str Int);
 use MooseX::Types -declare =>
   [
    qw(
@@ -25,6 +25,8 @@ use MooseX::Types -declare =>
       HsapiensX
       HsapiensY
       Platform
+      PositiveInt
+      QualityScore
       Reference
       ResultSet
       SequenomResultSet
@@ -82,6 +84,15 @@ subtype Platform,
   where { $_ eq 'fluidigm' || $_ eq 'sequenom' },
   message { "'$_' is not a valid genotyping platform" };
 
+subtype PositiveInt,
+  as Int,
+  where { $_ > 0 },
+  message { "Int is not larger than 0" };
+
+subtype QualityScore,
+  as Maybe[PositiveInt],
+  message { "'$_' is not a valid quality score, must be Int > 0 or undef" };
+
 class_type FluidigmResultSet, {
     class => 'WTSI::NPG::Genotyping::Fluidigm::AssayResultSet' };
 class_type SequenomResultSet, {
@@ -136,7 +147,11 @@ Keith James <kdj@sanger.ac.uk>, Iain Bancarz <ib5@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
+<<<<<<< HEAD
 Copyright (c) 2014-2015 Genome Research Limited. All Rights Reserved.
+=======
+Copyright (c) 2014, 2015 Genome Research Limited. All Rights Reserved.
+>>>>>>> iainrb.vcf_read_write
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/Types.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Types.pm
@@ -90,8 +90,8 @@ subtype PositiveInt,
   message { "Int is not larger than 0" };
 
 subtype QualityScore,
-  as Maybe[PositiveInt],
-  message { "'$_' is not a valid quality score, must be Int > 0 or undef" };
+  as PositiveInt,
+  message { "'$_' is not a valid quality score, must be Int > 0" };
 
 class_type FluidigmResultSet, {
     class => 'WTSI::NPG::Genotyping::Fluidigm::AssayResultSet' };

--- a/src/perl/lib/WTSI/NPG/Genotyping/VCF/AssayResultReader.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/VCF/AssayResultReader.pm
@@ -259,16 +259,23 @@ sub _parse_assay_results {
             my $snp_id = $ar->snp_assayed();
             my $snp = $self->snpset->named_snp($snp_id);
             my $call;
+            my $qscore = $ar->qscore();
+            # * Using $ar->qscore() in place of $qscore in the
+            # constructor does not work!
+            # * The $ar->qscore() is not correctly interpolated into the
+            # argument list, and the constructor dies because the argument
+            # list has an odd number of elements
+            # * TODO try to reproduce this error in a simplified test case
             if (is_GenderMarker($snp)) {
                 $call = WTSI::NPG::Genotyping::GenderMarkerCall->new(
                     snp      => $snp,
-                    qscore   => $ar->qscore(),
+                    qscore   => $qscore,
                     genotype => $ar->canonical_call()
                 );
             } else {
                 $call = WTSI::NPG::Genotyping::Call->new(
                     snp      => $snp,
-                    qscore   => $ar->qscore(),
+                    qscore   => $qscore,
                     genotype => $ar->canonical_call()
                 );
             }

--- a/src/perl/lib/WTSI/NPG/Genotyping/VCF/AssayResultReader.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/VCF/AssayResultReader.pm
@@ -23,6 +23,8 @@ use WTSI::NPG::Genotyping::VCF::VCFDataSet;
 
 with 'WTSI::DNAP::Utilities::Loggable';
 
+our $VERSION = '';
+
 our $NULL_GENOTYPE = 'NN';
 our $SEQUENOM_TYPE = 'sequenom'; # TODO remove redundancy wrt vcf_from_plex.pl
 our $FLUIDIGM_TYPE = 'fluidigm';
@@ -99,18 +101,18 @@ sub get_vcf_dataset {
     foreach my $snp (@{$self->snpset->snps}) {
         my @sample_calls;
         foreach my $sample (@$samples) {
-            push(@sample_calls, $calls->{$snp->name}{$sample});
+            push @sample_calls, $calls->{$snp->name}{$sample};
         }
         if (is_GenderMarker($snp)) {
             my ($x_row, $y_row) = $self->_gender_rows($snp, \@sample_calls);
-            push(@rows, $x_row);
-            push(@rows, $y_row);
+            push @rows, $x_row;
+            push @rows, $y_row;
         } else {
             my $data_row = WTSI::NPG::Genotyping::VCF::DataRow->new(
                 calls => \@sample_calls,
                 additional_info => "ORIGINAL_STRAND=".$snp->strand
             );
-            push(@rows, $data_row);
+            push @rows, $data_row;
         }
     }
     my $vcf_dataset = WTSI::NPG::Genotyping::VCF::VCFDataSet->new
@@ -142,7 +144,7 @@ sub _build_resultsets {
             } else {
                 $self->logcroak();
             }
-            push(@results, $resultSet);
+            push @results, $resultSet;
         }
     } else { # read input from local filesystem
          foreach my $input (@{$self->inputs}) {
@@ -158,7 +160,7 @@ sub _build_resultsets {
              } else {
                  $self->logcroak();
              }
-             push(@results, $resultSet);
+             push @results, $resultSet;
          }
     }
     return \@results;
@@ -189,6 +191,22 @@ sub _gender_rows {
         } elsif (!$call->is_call()) {
             push(@x_calls, $self->_generate_no_call($snp->x_marker));
             push(@y_calls, $self->_generate_no_call($snp->y_marker));
+            push @x_calls, WTSI::NPG::Genotyping::Call->new(
+                snp      => $snp->x_marker,
+                genotype => $call->genotype,
+                qscore   => $call->qscore,
+            );
+            push @y_calls, $self->_generate_no_call($snp->y_marker);
+        } elsif ($call->is_y_call()) {
+            push @x_calls, $self->_generate_no_call($snp->x_marker);
+            push @y_calls, WTSI::NPG::Genotyping::Call->new(
+                snp      => $snp->y_marker,
+                genotype => $call->genotype(),
+                qscore   => $call->qscore(),
+            );
+        } elsif (!$call->is_call()) {
+            push @x_calls, $self->_generate_no_call($snp->x_marker);
+            push @y_calls, $self->_generate_no_call($snp->y_marker);
         } else {
             $self->logcroak("Invalid genotype of '", $call->genotype,
                             "' for gender marker ", $snp->name,
@@ -244,13 +262,13 @@ sub _parse_assay_results {
             if (is_GenderMarker($snp)) {
                 $call = WTSI::NPG::Genotyping::GenderMarkerCall->new(
                     snp      => $snp,
-                    qscore   => $ar->quality_score(),
+                    qscore   => $ar->qscore(),
                     genotype => $ar->canonical_call()
                 );
             } else {
                 $call = WTSI::NPG::Genotyping::Call->new(
                     snp      => $snp,
-                    qscore   => $ar->quality_score(),
+                    qscore   => $ar->qscore(),
                     genotype => $ar->canonical_call()
                 );
             }
@@ -287,7 +305,7 @@ Iain Bancarz <ib5@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014-2015 Genome Research Limited. All Rights Reserved.
+Copyright (c) 2014, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/VCF/DataRow.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/VCF/DataRow.pm
@@ -10,7 +10,7 @@ with 'WTSI::DNAP::Utilities::Loggable';
 
 has 'qscore'    =>
     (is       => 'ro',
-     isa      => QualityScore,
+     isa      => 'Maybe['.QualityScore.']',
      default  => undef,
      documentation => 'Phred quality score for alternate reference allele. Not to be confused with quality scores of the calls for each sample.'
  );

--- a/src/perl/lib/WTSI/NPG/Genotyping/VCF/DataRow.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/VCF/DataRow.pm
@@ -84,7 +84,7 @@ sub BUILD {
 
 =cut
 
-sub str() {
+sub str {
     my ($self,)= @_;
     my @fields = ();
     my $alt;

--- a/src/perl/lib/WTSI/NPG/Genotyping/VCF/DataRow.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/VCF/DataRow.pm
@@ -8,11 +8,11 @@ use WTSI::NPG::Genotyping::Types qw(:all);
 
 with 'WTSI::DNAP::Utilities::Loggable';
 
-has 'qual'    =>
+has 'qscore'    =>
     (is       => 'ro',
-     isa      => 'Int',
-     default  => -1,
-     documentation => 'Phred quality score for alternate reference allele; -1 if missing. Not to be confused with quality scores of the calls for each sample.'
+     isa      => QualityScore,
+     default  => undef,
+     documentation => 'Phred quality score for alternate reference allele. Not to be confused with quality scores of the calls for each sample.'
  );
 
 has 'filter'  =>
@@ -58,6 +58,8 @@ has 'is_haploid' =>
 
 # NB this class does not have the sample names; they are stored in VCF header
 
+our $VERSION = '';
+
 # genotype sub-fields GT = genotype; GQ = genotype quality; DP = read depth
 our $GENOTYPE_FORMAT = 'GT:GQ:DP';
 our $DEPTH_PLACEHOLDER = 1;
@@ -72,37 +74,38 @@ sub BUILD {
 }
 
 
-=head2 to_string
+
+=head2 str
 
   Arg [1]    : None
-  Example    : my $row_string = $data_row->to_string();
+  Example    : my $row_string = $data_row->str();
   Description: Return a string for output in the body of a VCF file.
   Returntype : Str
 
 =cut
 
-sub to_string {
+sub str() {
     my ($self,)= @_;
     my @fields = ();
     my $alt;
     if ($self->is_haploid) { $alt = '.'; }
     else { $alt = $self->snp->alt_allele; }
-    my $qual;
-    if ($self->qual == -1) { $qual = '.'; }
-    else {$qual = $self->qual; }
-    push(@fields, ($self->vcf_chromosome_name,
+    my $qscore;
+    if (!defined($self->qscore)) { $qscore = '.'; }
+    else {$qscore = $self->qscore; }
+    push @fields, ($self->vcf_chromosome_name,
                    $self->snp->position,
                    $self->snp->name,
                    $self->snp->ref_allele,
                    $alt,
-                   $qual,
+                   $qscore,
                    $self->filter,
                    $self->additional_info,
-                   $GENOTYPE_FORMAT));
+                   $GENOTYPE_FORMAT);
     foreach my $call (@{$self->calls}) {
-        push(@fields, $self->_call_to_vcf_field($call));
+        push @fields, $self->_call_to_vcf_field($call);
     }
-    return join("\t", @fields);
+    return join "\t", @fields;
 }
 
 sub _build_haploid_status {
@@ -136,7 +139,7 @@ sub _build_vcf_chromosome_name {
     if ($chr =~ /^Chr/) {
         $chr =~ s/Chr//; # strip off 'Chr' prefix, if any
     }
-    unless (is_HsapiensChromosomeVCF($chr)) {
+    unless (is_HsapiensChromosome($chr)) {
         $self->logcroak("Unknown chromosome string: '",
                         $self->snp->chromosome, "'");
     }
@@ -150,7 +153,7 @@ sub _call_to_vcf_field {
     if ($self->snp->strand eq '-') { # reverse strand, use complement of call
         $call = $call->complement();
     }
-    my @alleles = split(//, $call->genotype);
+    my @alleles = split //, $call->genotype;
     my $allele_total;
     if ($self->is_haploid()) { $allele_total = 1; }
     else { $allele_total = 2; }
@@ -158,24 +161,24 @@ sub _call_to_vcf_field {
     my @vcf_alleles;
     while ($i < $allele_total) {
         my $allele = $alleles[$i];
-        if ($allele eq $self->snp->ref_allele) { push(@vcf_alleles, '0'); }
-        elsif ($allele eq $self->snp->alt_allele) { push(@vcf_alleles, '1'); }
-        elsif ($allele eq $NULL_ALLELE) { push(@vcf_alleles, '.'); }
+        if ($allele eq $self->snp->ref_allele) { push @vcf_alleles, '0'; }
+        elsif ($allele eq $self->snp->alt_allele) { push @vcf_alleles, '1'; }
+        elsif ($allele eq $NULL_ALLELE) { push @vcf_alleles, '.'; }
         $i++;
     }
-    my $vcf_call = join('/', @vcf_alleles);
-    my $qual;
+    my $vcf_call = join '/', @vcf_alleles;
+    my $qscore;
     if (defined($call->qscore)) {
         if ($call->qscore == -1) {
-            $qual = $DEFAULT_QUALITY_STRING;
+            $qscore = $DEFAULT_QUALITY_STRING;
         } else {
-            $qual = $call->qscore;
+            $qscore = $call->qscore;
         }
     } else {
-        $qual = $DEFAULT_QUALITY_STRING;
+        $qscore = $DEFAULT_QUALITY_STRING;
     }
-    my @subfields = ($vcf_call, $qual, $DEPTH_PLACEHOLDER);
-    return join(':', @subfields);
+    my @subfields = ($vcf_call, $qscore, $DEPTH_PLACEHOLDER);
+    return join ':', @subfields;
 }
 
 no Moose;

--- a/src/perl/lib/WTSI/NPG/Genotyping/VCF/GtcheckWrapper.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/VCF/GtcheckWrapper.pm
@@ -77,13 +77,13 @@ sub run {
              environment => $self->environment,
              logger      => $self->logger)->run->split_stdout;
     }
-    $self->logger->info("bcftools arguments: ".join(" ", @args));
-    $self->logger->debug("bcftools command output:\n".join("", @raw_results));
+    $self->logger->info("bcftools arguments: ".join " ", @args );
+    $self->logger->debug("bcftools command output:\n".join "", @raw_results);
     my %results;
     my $max = 0; # maximum pairwise discordance
     foreach my $line (@raw_results) {
         if ($line !~ /^CN/) { next; }
-        my @words = split(/\s+/, $line);
+        my @words = split /\s+/, $line;
         my $discordance = $words[1];
         my $sites = $words[2];
         my $sample_i = $words[4];
@@ -275,7 +275,7 @@ Iain Bancarz <ib5@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014-2015 Genome Research Limited. All Rights Reserved.
+Copyright (c) 2014, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/VCF/Header.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/VCF/Header.pm
@@ -27,6 +27,8 @@ has 'source' => (
     documentation => 'Standard VCF field to identify the data source'
 );
 
+our $VERSION = '';
+
 our $VCF_VERSION = 'VCFv4.0'; # version of VCF format in use
 our $INFO = '<ID=ORIGINAL_STRAND,Number=1,Type=String,'.
             'Description="Direction of strand in input file">';
@@ -37,23 +39,23 @@ our @FORMAT = (
 );
 our @COLUMN_HEADS = qw/CHROM POS ID REF ALT QUAL FILTER INFO FORMAT/;
 
-=head2 to_string
+=head2 str
 
   Arg [1]    : None
 
-  Example    : $data_row->to_string
+  Example    : $head_string = $header->str()
   Description: Return a string for output as the header of a VCF file.
   Returntype : Str
 
 =cut
 
-sub to_string {
+sub str {
     my ($self) = @_;
     my @header;
-    push(@header, '##fileformat='.$VCF_VERSION);
+    push @header, '##fileformat='.$VCF_VERSION;
     my $date = DateTime->now(time_zone=>'local')->ymd('');
-    push(@header, '##fileDate='.$date);
-    push(@header, '##source='.$self->source);
+    push @header, '##fileDate='.$date;
+    push @header, '##source='.$self->source;
     if (defined($self->chromosome_lengths)) {
         my @chromosomes = sort(keys(%{$self->chromosome_lengths}));
         foreach my $chr (@chromosomes) {
@@ -61,17 +63,17 @@ sub to_string {
             my $contig = '##contig=<ID='.$chr.
                 ',length='.$self->chromosome_lengths->{$chr}.
                 ',species="Homo sapiens">';
-            push(@header, $contig);
+            push @header, $contig;
         }
     }
-    push(@header, '##INFO='.$INFO);
+    push @header, '##INFO='.$INFO;
     foreach my $format_field (@FORMAT) {
-        push(@header, '##FORMAT='.$format_field);
+        push @header, '##FORMAT='.$format_field;
     }
     my @colHeads = @COLUMN_HEADS;
-    push(@colHeads, @{$self->sample_names});
-    push(@header, "#".join("\t", @colHeads));
-    return join("\n", @header);
+    push @colHeads, @{$self->sample_names};
+    push @header, "#".join "\t", @colHeads;
+    return join "\n", @header;
 }
 
 no Moose;

--- a/src/perl/lib/WTSI/NPG/Genotyping/VCF/VCFDataSet.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/VCF/VCFDataSet.pm
@@ -34,6 +34,8 @@ has 'sort_output' =>
     documentation => 'If true, output rows are sorted in (chromosome, position) order',
     );
 
+our $VERSION = '';
+
 our $X_CHROM_NAME = 'X';
 our $Y_CHROM_NAME = 'Y';
 
@@ -46,27 +48,27 @@ sub BUILD {
 }
 
 
-=head2 to_string
+=head2 str
 
   Arg [1]    : None
-  Example    : my $vcf_string = $vcf_data_set->to_string()
+  Example    : my $vcf_string = $vcf_data_set->str()
   Description: Return a string which can be output as a VCF file.
   Returntype : Str
 
 =cut
 
-sub to_string {
+sub str {
     my ($self) = @_;
     my @output;
     foreach my $row (@{$self->data}) {
-        push(@output, $row->to_string());
+        push @output, $row->str();
     }
     if ($self->sort_output) {
         @output = $self->_sort_output_lines(\@output);
     }
     # prepend header to output
-    unshift(@output, $self->header->to_string());
-    return join("\n", @output);
+    unshift @output, $self->header->str();
+    return join "\n", @output;
 }
 
 =head2 write_vcf
@@ -82,7 +84,7 @@ sub to_string {
 sub write_vcf {
     # convert to string and write to the path (or - for STDOUT)
     my ($self, $output) = @_;
-    my $outString = $self->to_string();
+    my $outString = $self->str();
     if ($output) {
         my $out;
         $self->logger->info("Printing VCF output to $output");
@@ -124,13 +126,13 @@ sub _sort_output_lines {
         if ($line =~ /^#/) {
             push @output, $line;
         } else {
-            push(@data, $line);
-            my @fields = split(/\s+/, $line);
-            my $chr = shift(@fields);
+            push @data, $line;
+            my @fields = split /\s+/, $line ;
+            my $chr = shift @fields;
             if ($chr eq $X_CHROM_NAME) { $chr = 23; }
             elsif ($chr eq $Y_CHROM_NAME) { $chr = 24; }
             $chrom{$line} = $chr;
-            $pos{$line} = shift(@fields);
+            $pos{$line} = shift @fields;
         }
     }
     @data = sort { $chrom{$a} <=> $chrom{$b} || $pos{$a} <=> $pos{$b} } @data;

--- a/src/perl/t/WTSI/NPG/Genotyping/GenderMarkerCallTest.pm
+++ b/src/perl/t/WTSI/NPG/Genotyping/GenderMarkerCallTest.pm
@@ -1,0 +1,113 @@
+use strict;
+use warnings;
+
+use Log::Log4perl;
+use List::AllUtils qw(all);
+
+use base qw(Test::Class);
+use Test::Exception;
+use Test::More tests => 24;
+
+Log::Log4perl::init('./etc/log4perl_tests.conf');
+
+BEGIN { use_ok('WTSI::NPG::Genotyping::GenderMarkerCall'); }
+
+use WTSI::NPG::Genotyping::GenderMarkerCall;
+use WTSI::NPG::Genotyping::SNPSet;
+
+my $data_path = './t/snpset';
+my $data_file = 'qc.tsv';
+
+sub require : Test(1) {
+  require_ok('WTSI::NPG::Genotyping::GenderMarkerCall');
+}
+
+sub constructor : Test(4) {
+  my $snpset = WTSI::NPG::Genotyping::SNPSet->new("$data_path/$data_file");
+  my $snp = $snpset->named_snp('GS34251');
+  new_ok('WTSI::NPG::Genotyping::GenderMarkerCall',
+         [genotype => 'TT',
+          snp      => $snp]);
+  new_ok('WTSI::NPG::Genotyping::GenderMarkerCall',
+         [genotype => 'CC',
+          snp      => $snp]);
+  new_ok('WTSI::NPG::Genotyping::GenderMarkerCall',
+         [genotype => 'NN',
+          snp      => $snp]);
+  dies_ok {
+      WTSI::NPG::Genotyping::GenderMarkerCall->new(
+          {genotype => 'CT',
+           snp      => $snp});
+  } "Cannot construct gender marker from heterozygous genotype";
+}
+
+sub equivalent : Test(8) {
+    my $snpset = WTSI::NPG::Genotyping::SNPSet->new("$data_path/$data_file");
+    my $snp = $snpset->named_snp('GS34251'); # TT/CC
+    my $non_gendermarker_snp = $snpset->named_snp('rs11096957'); # TG
+    my $call = WTSI::NPG::Genotyping::GenderMarkerCall->new
+        (snp      => $snp,
+         genotype => 'TT',
+         is_call  => 1);
+    my $same_call = WTSI::NPG::Genotyping::GenderMarkerCall->new
+        (snp      => $snp,
+         genotype => 'TT',
+         is_call  =>  1);
+    ok($call->equivalent($same_call), 'Exact equivalent');
+    ok($same_call->equivalent($call), 'Exact equivalent (reciprocal)');
+    ok($call->equivalent($call->complement()), 'Complement equivalent');
+    ok($call->complement->equivalent($call),
+       'Complement equivalent (reciprocal)');
+    my $non_gendermarker_call = WTSI::NPG::Genotyping::Call->new
+        (snp      => $non_gendermarker_snp,
+         genotype => 'TT',
+         is_call  =>  1);
+    dies_ok{
+        $call->equivalent($non_gendermarker_call);
+    } "Dies on equivalence check with non-gendermarker call";
+    my $no_call = WTSI::NPG::Genotyping::GenderMarkerCall->new(
+        snp      => $snp,
+        genotype => 'TT',
+        is_call  => 0);
+    ok(!$call->equivalent($no_call), 'No call not equivalent');
+    ok(!$no_call->equivalent($call), 'No call not equivalent (reciprocal)');
+    ok(!$no_call->equivalent($no_call), 'No call not equivalent with self');
+}
+
+sub gender_attribute : Test(6) {
+    my $snpset = WTSI::NPG::Genotyping::SNPSet->new("$data_path/$data_file");
+    my $snp = $snpset->named_snp('GS34251');
+    my $x_call = WTSI::NPG::Genotyping::GenderMarkerCall->new(
+        genotype => 'TT',
+        snp      => $snp
+    );
+    ok($x_call->is_x_call(), "Female gender marker call is an X call");
+    ok(!$x_call->is_y_call(), "Female gender marker call is not a Y call");
+    my $y_call = WTSI::NPG::Genotyping::GenderMarkerCall->new(
+        genotype => 'CC',
+        snp      => $snp
+    );
+    ok(!$y_call->is_x_call(), "Male gender marker call is not an X call");
+    ok($y_call->is_y_call(), "Male gender marker call is a Y call");
+    my $no_call = WTSI::NPG::Genotyping::GenderMarkerCall->new(
+        genotype => 'NN',
+        snp      => $snp,
+        is_call  => 0
+    );
+    ok(!$no_call->is_x_call(), "Null gender marker call is not an X call");
+    ok(!$no_call->is_y_call(), "Null gender marker call is not a Y call");
+}
+
+sub complement : Test(4) {
+   my $snpset = WTSI::NPG::Genotyping::SNPSet->new("$data_path/$data_file");
+   my $snp = $snpset->named_snp('GS34251');
+   my $x_call = WTSI::NPG::Genotyping::GenderMarkerCall->new(
+       genotype => 'TT',
+       snp      => $snp
+   );
+   isa_ok($x_call->complement, 'WTSI::NPG::Genotyping::GenderMarkerCall',
+      "Complement of a GenderMarkerCall is another GenderMarkerCall");
+   is('AA', $x_call->complement->genotype, 'Complement call');
+   ok(!$x_call->is_complement, 'Is not complemented');
+   ok($x_call->complement->is_complement, 'Is complemented');
+}

--- a/src/perl/t/gender_marker_call.t
+++ b/src/perl/t/gender_marker_call.t
@@ -1,0 +1,9 @@
+
+use utf8;
+
+use strict;
+use warnings;
+
+use WTSI::NPG::Genotyping::GenderMarkerCallTest;
+
+Test::Class->runtests;


### PR DESCRIPTION
- Remove parentheses from calls to push/split/join
- Consistent naming of quality score attributes as "qscore"
- Added QualityScore type and removed VCFChromosome type in Types.pm
- Renamed to_string() methods as str()
- Override complement method of parent class in GenderMarkerCall
- Tests for GenderMarkerCall
- Added empty version string for perlcritic
