### PR TITLE
Enabled more Perl critic tests

### DIFF
--- a/src/perl/bin/check_duplicates_bed.pl
+++ b/src/perl/bin/check_duplicates_bed.pl
@@ -93,7 +93,7 @@ if ($help) {
 }
 
 # generate hashes of chromosome and position for each SNP in .bim file
-open my $bim, "<", $bfile.".bim" or die qq(Unable to open $bfile.bim);
+open my $bim, "<", $bfile.".bim" or die "Unable to open $bfile.bim\n";
 while (<$bim>) {
     my ($chr, $snp, $pos) = (split)[0, 1, 3];
     $chr{$snp} = $chr;
@@ -103,7 +103,7 @@ close $bim;
 
 # open genotyping SNP results file (defaults to snp_cr_af.txt) and filter on MAF and CR
 # populate a hash %snps: Keys=chromosomes, values = lists of (snp_name, snp_position) pairs
-open my $snpfile, "<", $af or die "Cannot read SNP file '$af': $!";
+open my $snpfile, "<", $af or die "Cannot read SNP file '$af': $!\n";
 while (<$snpfile>) {
     my ($snp, $cr, $maf) = (split)[0, 1, 5];
     next unless $chr{$snp};
@@ -111,7 +111,7 @@ while (<$snpfile>) {
     next if $maf < $maf_min || $maf > $maf_max;
     push @{$snps{$chr{$snp}}}, [ $snp, $pos{$snp} ];
 }
-close $snpfile or die $!;
+close $snpfile or die "Failed to close $snpfile: $!\n";
 
 # filter to ensure minimum distance between SNPs; generates @use_snps array
 foreach my $chr (keys %snps) {
@@ -126,7 +126,7 @@ foreach my $chr (keys %snps) {
 	}
     }
 }
-open my $logfile, ">", $log or die $!;
+open my $logfile, ">", $log or die "Failed to open $log for writing: $!\n";
 print $logfile scalar(@use_snps), " available SNPs found for duplicate check\n";
 if (@use_snps > $max_snps) {
     @use_snps = @use_snps[0 .. $max_snps - 1]; # truncate @use_snps if too large
@@ -143,8 +143,8 @@ print $snp_file map { $_ . "\n" } @use_snps;
 my $full = $dir.'/duplicate_full.txt';
 my $summary = $dir.'/duplicate_summary.txt';
 my $cmd = "pairwise_concordance_bed -n $snp_file -f $full -m $summary $bfile";
-system($cmd) && die qq(Error running command "$cmd": $!);
+system($cmd) && die qq(Error running command "$cmd": $!\n);
 
 # gzip pairwise output file; can be quite large, >> 1 GB
 $cmd = "gzip -f $full";
-system($cmd) && die qq(Error running command "$cmd": $!);;
+system($cmd) && die qq(Error running command "$cmd": $!\n);;

--- a/src/perl/bin/check_identity_bed.pl
+++ b/src/perl/bin/check_identity_bed.pl
@@ -70,17 +70,19 @@ Options:
     exit(0);
 }
 
-if (!($plink)) {
-    croak "Must supply a Plink binary input prefix";
-} elsif (!(-e $plink.'.bed' && -e $plink.'.bim' && -e $plink.'.fam')) {
-    croak "Prefix '$plink' is not a valid Plink binary dataset; one or more files missing";
-} elsif ($outDir && !(-e $outDir && -d $outDir)) {
-    croak "Output '$outDir' does not exist or is not a directory";
-} elsif (!($dbPath)) {
-    croak "Must supply an SQLite pipeline database path";
-} elsif (!(-e $dbPath)) {
-    croak "Database path $dbPath does not exist"; 
+$plink or die "Must supply a Plink binary input prefix\n";
+foreach my $part (map { $plink . $_ } qw(.bed .bim .fam)) {
+  -e $part or die "Prefix '$plink' is not a valid Plink binary dataset; " .
+    "'$part' is missing\n";
 }
+
+if ($outDir) {
+  -e $outDir or die "Output '$outDir' does not exist\n";
+  -d $outDir or die "Output '$outDir' is not a directory\n";
+}
+
+$dbPath or die "Must supply an SQLite pipeline database path\n";
+-e $dbPath or die "Database path '$dbPath' does not exist\n";
 
 $outDir ||= getcwd();
 $minSNPs ||= 8;
@@ -89,14 +91,14 @@ if (!$minIdent) {
         my %thresholds = readThresholds($configPath);
         $minIdent = $thresholds{'identity'};
     } else {
-        croak("Must supply a value for either --min_ident or --config");
+        die "Must supply a value for either --min_ident or --config\n";
     }
 }
 if ($minIdent < 0 || $minIdent > 1) {
-    croak("Minimum identity value must be a number between 0 and 1");
+    die "Minimum identity value must be a number between 0 and 1\n";
 }
 if ($swap && ($swap < 0 || $swap > 1)) {
-    croak("Swap threshold must be a number between 0 and 1");
+    die "Swap threshold must be a number between 0 and 1\n";
 }
 $swap ||= $swapDefault;
 

--- a/src/perl/bin/create_test_database.pl
+++ b/src/perl/bin/create_test_database.pl
@@ -106,7 +106,7 @@ sub createDummyCalls {
     my @calls;
     my @lines = read_file($plexPath);
     foreach my $line (@lines) {
-        if ($line =~ /^#SNP_NAME/) { next; }
+        if ($line =~ m{^#SNP_NAME}msx) { next; }
         $csv->parse($line);
         my @fields = $csv->fields();
         my ($snp_name, $ref, $alt, $chrom, $pos, $strand) = @fields;

--- a/src/perl/bin/filter_illuminus_output.pl
+++ b/src/perl/bin/filter_illuminus_output.pl
@@ -66,7 +66,7 @@ sub run {
   my $pr_offset = 3; # 3 leading columns in probability files
 
   my $gt_separator = "\t"; # Different column separators for genotype
-  my $pr_separator = " ";  # and probability files. Yes, really.
+  my $pr_separator = ' ';  # and probability files. Yes, really.
   my $gt_col_group = 1; # Genotype data has one column per sample
   my $pr_col_group = 4; # Probability data comes in groups of 4
                         # columns per sample
@@ -177,7 +177,8 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2011-2012 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2011, 2012, 2015 Genome Research Limited. All Rights
+Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/bin/illuminus.pl
+++ b/src/perl/bin/illuminus.pl
@@ -90,7 +90,7 @@ if ($start && $end) {
   push(@command, '-s', $start, $end);
 }
 
-if ($chromosome eq 'X' || $chromosome eq 'Y' || $chromosome =~ /^M/) {
+if ($chromosome eq 'X' || $chromosome eq 'Y' || $chromosome =~ m{^M}msx) {
   write_gender_codes($gender_file, $chromosome, \@samples);
   push(@command, '-x', $gender_file);
 }
@@ -216,7 +216,7 @@ sub write_gender_codes {
     or die "Failed to open '$file' for writing: $!\n";
   foreach my $sample (@$samples) {
     my $code = 0;
-    if ($chromosome =~ /^M/) {
+    if ($chromosome =~ m{^M}msx) {
       $code = 1;
     } else {
       $code = $sample->{'gender_code'};
@@ -290,7 +290,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2012 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2012, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/bin/manifest_plex_intersection.pl
+++ b/src/perl/bin/manifest_plex_intersection.pl
@@ -52,9 +52,9 @@ sub getIntersectingSNPsManifest {
     my @manifest;
     open my $in, "<", $manifestPath || croak("Cannot open '$manifestPath'");
     while (<$in>) {
-	if (/^Index/) { next; } # skip header line
+	if (/^Index/msx) { next; } # skip header line
 	chomp;
-	my @words = split(/,/);
+	my @words = split /,/msx;
 	push(@manifest, $words[1]);
     }
     close $in || croak("Cannot close '$manifestPath'");
@@ -108,7 +108,7 @@ Iain Bancarz <ib5@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2014, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/bin/plate_heatmap_index.pl
+++ b/src/perl/bin/plate_heatmap_index.pl
@@ -34,10 +34,10 @@ sub getPlateName {
     # prefix may *not* contain _'s, plate may contain .'s and _'s)
     my $plotPath = shift;
     my $plotName = basename($plotPath);
-    my @items = split(/_/, $plotName);
+    my @items = split /_/msx, $plotName;
     my @tail = splice(@items, 2);
     my $tail = join('_', @tail);
-    @items = split(/\./, $tail);
+    @items = split /[.]/msx, $tail;
     my $name = shift(@items);
     return $name;
 }
@@ -66,7 +66,7 @@ my ($experiment, $plotDir, $outFileName) = @ARGV; # experiment name, input/outpu
 if (@ARGV!=3) { 
     die "Usage: $0 experiment_name input/output_directory output_filename\n";
 } elsif (!(-e $plotDir && -d $plotDir)) {
-    die "Output path '$plotDir' does not exist or is not a directory";
+    die "Output path '$plotDir' does not exist or is not a directory\n";
 } 
 my @refs = getPlateInfo($plotDir);
 my @plates = @{shift(@refs)};
@@ -75,7 +75,7 @@ my %hetPlots = %{shift(@refs)};
 my %magPlots = %{shift(@refs)};
 # must write index to given plot directory -- otherwise links are broken
 my $outPath = $plotDir.'/'.$outFileName;
-open my $out, ">", $outPath || die "Cannot open output path $outPath: $!";
+open my $out, ">", $outPath || die "Cannot open output path $outPath: $!\n";
 print $out header(-type=>''), # create the HTTP header; content-type declaration not needed for writing to file
     start_html(-title=>"$experiment: Plate heatmap index",
 	       -author=>'Iain Bancarz <ib5@sanger.ac.uk>',

--- a/src/perl/bin/plot_box_bean.pl
+++ b/src/perl/bin/plot_box_bean.pl
@@ -63,11 +63,21 @@ $type = 'both';
 $outDir ||= '.';
 $title ||= "UNTITLED";
 
-unless ($mode eq "cr" || $mode eq "het" || $mode eq "xydiff") { die "Illegal mode argument: $mode: $!"; }
-unless ($type eq "box" || $type eq "bean" || $type eq "both") { die "Illegal type argument: $type: $!"; }
-if ((!$dbpath) && (!$inipath)) { croak "Must supply at least one of pipeline database path and .ini path!"; }
-if ($dbpath && !(-r $dbpath)) { croak "Cannot read pipeline database path $dbpath"; }
-if ($inipath && !(-r $inipath)) { croak "Cannot read .ini path $inipath"; }
+unless ($mode eq "cr" || $mode eq "het" || $mode eq "xydiff") {
+  die "Illegal mode argument: $mode: $!\n";
+}
+unless ($type eq "box" || $type eq "bean" || $type eq "both") {
+  die "Illegal type argument: $type: $!\n";
+}
+if ((!$dbpath) && (!$inipath)) {
+  die "Must supply at least one of pipeline database path and .ini path!\n";
+}
+if ($dbpath && !(-r $dbpath)) {
+  die "Cannot read pipeline database path $dbpath\n";
+}
+if ($inipath && !(-r $inipath)) {
+  die "Cannot read .ini path $inipath\n";
+}
 
 sub writeBoxplotInput {
     # read given input filehandle; write plate name and data to given output filehandle
@@ -76,10 +86,12 @@ sub writeBoxplotInput {
     my $inputOK = 0;
     my %plateLocs = getPlateLocationsFromPath($dbpath, $inipath);
     while (<$input>) {
-	if (/^#/) { next; } # ignore comments
+	if (m{^\#}msx) { next; } # ignore comments
 	chomp;
 	my @words = split;
-	unless ($plateLocs{$words[0]}) { croak "No plate location for sample '$words[0]'; exiting"; }
+	unless ($plateLocs{$words[0]}) {
+      die "No plate location for sample '$words[0]'; exiting\n";
+    }
 	my ($plate, $addressLabel) = @{$plateLocs{$words[0]}};
 	if ($plate) {
 	    $inputOK = 1; # require at least one sample with a valid plate!

--- a/src/perl/bin/plot_cr_het_density.pl
+++ b/src/perl/bin/plot_cr_het_density.pl
@@ -80,7 +80,7 @@ sub readCrHet {
     my @coords = ();
     my ($hetMin, $hetMax) = (1, 0);
     while (<$input>) {
-	if (/^#/) { next; } # ignore comments
+	if (m{^\#}msx) { next; } # ignore comments
 	chomp;
 	my @words = split;
 	my $cr = $words[$crIndex];
@@ -123,7 +123,8 @@ sub run {
     my ($coordsRef, $hetMin, $hetMax) = readCrHet($input);
     my ($xmin, $xmax, $xsteps, $ysteps) = (0, 41, 40, 40);
     my @counts = getBinCounts($coordsRef, $xmin, $xmax, $xsteps, $hetMin, $hetMax, $ysteps);
-    open $output, ">", $heatText || die "Cannot open output path $heatText: $!";
+    open $output, ">", $heatText ||
+      die "Cannot open output path $heatText: $!\n";
     writeTable(\@counts, $output);
     close $output;
     @args = ($heatPlotScript, $heatText, $title, $hetMin, $hetMax, $heatPdf);
@@ -131,7 +132,8 @@ sub run {
     my $plotsOK = WTSI::NPG::Genotyping::QC::QCPlotTests::wrapPlotCommand(\@args, \@outputs);
     ### do scatterplot & histograms ###
     if ($plotsOK) {
-	open $output, ">", $scatterText || die "Cannot open output path $scatterText: $!";
+      open $output, ">", $scatterText ||
+        die "Cannot open output path $scatterText: $!\n";
 	writeTable($coordsRef, $output); # note that CR coordinates have been transformed to phred scale
 	close $output;
 	my $scatterPlotScript = "plotCrHetDensity.R";

--- a/src/perl/bin/plot_fail_causes.pl
+++ b/src/perl/bin/plot_fail_causes.pl
@@ -70,7 +70,7 @@ Unspecified options will receive default values.
 
 my @outputPaths;
 my @outNames = ($failText, $comboText, $causeText, $comboPdf, $causePdf, $comboPng, $causePng, $crHetFail, $scatterPdf, $detailPdf, $scatterPng, $detailPng);
-if ($outputDir !~ /\/$/) { $outputDir .= '/'; }
+if ($outputDir !~ m{\/$}msx) { $outputDir .= '/'; }
 foreach my $name (@outNames) { push(@outputPaths, $outputDir.$name); }
 
 sub containsFailedSample {
@@ -164,14 +164,16 @@ sub writeFailCounts {
             $combinedFails{$combo}++;
         };
     }
-    open my $out, ">", $failText || die "Cannot open output file $failText: $!";
+    open my $out, ">", $failText ||
+      die "Cannot open output file $failText: $!\n";
     my @metrics = sort(keys(%singleFails));
     foreach my $metric (@metrics) {
         print $out $metric."\t".$singleFails{$metric}."\n";
     }
     close $out;
     my @failCombos = sort(keys(%combinedFails));
-    open $out, ">", $comboText || die "Cannot open output file $failText: $!"; 
+    open $out, ">", $comboText ||
+      die "Cannot open output file $failText: $!\n";
     foreach my $combo (@failCombos) {
         print $out $combo."\t".$combinedFails{$combo}."\n";
     }
@@ -189,7 +191,7 @@ sub writeFailedCrHet {
     my @header = qw(sample cr het);
     my @keys = qw(duplicate gender identity magnitude);
     push(@header, @keys);
-    open my $out, ">", $outPath || die "Cannot open output path $outPath: $!";
+    open my $out, ">", $outPath || die "Cannot open output path $outPath: $!\n";
     print $out join("\t", @header)."\n";
     foreach my $fieldsRef (@data) {
         my @fields = splice(@$fieldsRef, 0, 3);

--- a/src/perl/bin/publish_expression_analysis.pl
+++ b/src/perl/bin/publish_expression_analysis.pl
@@ -246,7 +246,7 @@ sub find_data_files {
   my $beadchips_patt = join('|', @beadchips);
   my $sections_patt = join('|', @sections);
   my $filename_regex =
-    qr{($beadchips_patt)_($sections_patt)_$channel.(idat|xml)$}mi;
+    qr{($beadchips_patt)_($sections_patt)_$channel.(idat|xml)$}msxi;
 
   $log->debug("Finding sample data files matching regex '$filename_regex'");
 
@@ -298,7 +298,8 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2014, 2015 Genome Research Limited. All Rights
+Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/bin/publish_fluidigm_genotypes.pl
+++ b/src/perl/bin/publish_fluidigm_genotypes.pl
@@ -111,7 +111,7 @@ sub run {
     (epoch => $end->epoch)->subtract(days => $days);
 
   my $dir_test = modified_between($begin->epoch, $end->epoch);
-  my $dir_regex = qr{^[0-9]{10}$}msxi;
+  my $dir_regex = qr{^\d{10}$}msxi;
   my $source_dir = abs_path($source);
   my $relative_depth = 2;
 

--- a/src/perl/bin/ready_external.pl
+++ b/src/perl/bin/ready_external.pl
@@ -8,6 +8,7 @@ use warnings;
 use strict;
 use File::Basename;
 use Getopt::Long;
+use List::AllUtils qw(any);
 use Log::Log4perl qw(:easy);
 use Pod::Usage;
 
@@ -82,7 +83,7 @@ sub run {
        on_connect_do  => 'PRAGMA foreign_keys = ON');
 
   my @valid_designs = map { $_->name } $pipedb->snpset->all;
-  unless (grep { $chip_design eq $_ } @valid_designs ) {
+  unless (any { $chip_design eq $_ } @valid_designs ) {
     die "Invalid chip design '$chip_design'. Valid designs are: [" .
       join(", ", @valid_designs) . "]\n";
   }

--- a/src/perl/bin/ready_external.pl
+++ b/src/perl/bin/ready_external.pl
@@ -17,7 +17,7 @@ use WTSI::NPG::Genotyping::Database::Pipeline;
 
 our $VERSION = '';
 our $DEFAULT_INI = $ENV{HOME} . "/.npg/genotyping.ini";
-our $ID_REGEX = qr/^[A-Za-z0-9-._]{4,}$/;
+our $ID_REGEX = qr{^[\w.-]{4,}$}msx;
 
 Log::Log4perl->easy_init($ERROR);
 
@@ -167,7 +167,7 @@ sub parse_manifest {
     chomp($line);
     ++$i;
 
-    next if $line =~ m/^\s*$/msx;
+    next if $line =~ m{^\s*$}msx;
 
     # Fields:
     # Sample name
@@ -175,7 +175,7 @@ sub parse_manifest {
     # GTC file path
     # Green IDAT file path
     # Red IDAT file path
-    my @fields = split(/\t/, $line, -1);
+    my @fields = split /\t/msx, $line, -1;
     my $num_fields = scalar @fields;
 
     unless ($num_fields == 6) {
@@ -196,7 +196,7 @@ sub parse_manifest {
 
     unless ($sample->{beadchip}) {
       my $gtc = basename($sample->{gtc_path});
-      my ($beadchip_guess) = $gtc =~ m/^(\d{10})_/msx;
+      my ($beadchip_guess) = $gtc =~ m{^(\d{10})_}msx;
 
       if ($beadchip_guess) {
         $sample->{beadchip} = $beadchip_guess;
@@ -330,7 +330,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2012 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2012, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/bin/ready_infinium.pl
+++ b/src/perl/bin/ready_infinium.pl
@@ -29,7 +29,7 @@ our $AUTOCALL_PASS = 'Pass';
 our $WTSI_NAMESPACE = 'wtsi';
 our $DEFAULT_INI = $ENV{HOME} . "/.npg/genotyping.ini";
 our $SNPSETS_INI = 'snpsets.ini';
-our $ID_REGEX = qr/^[A-Za-z0-9-._]{4,}$/;
+our $ID_REGEX = qr{^[\w.-]{4,}$}msx;
 
 our $SEQUENOM = 'sequenom';
 our $FLUIDIGM = 'fluidigm';
@@ -206,7 +206,7 @@ sub run {
                    join(", ", map { $_->name } $pipedb->snpset->all), "]");
   }
   if ($chip_design) {
-    unless (grep { /^$chip_design$/ } @chip_designs) {
+    unless (grep { /^$chip_design$/msx } @chip_designs) {
         $log->logcroak("Invalid chip design '",
                        $chip_design, "'. Valid designs are: [ ",
                        join(", ", @chip_designs), "]");
@@ -271,7 +271,6 @@ sub run {
        print_pre_report($supplier, $project_title, $namespace, $snpset)
          if $verbose;
 
-       # FIXME -- cache this in the database handle
        my %cache;
        my @samples;
 

--- a/src/perl/bin/ready_infinium.pl
+++ b/src/perl/bin/ready_infinium.pl
@@ -8,7 +8,7 @@ use warnings;
 use strict;
 use Config::IniFiles;
 use Getopt::Long;
-use List::AllUtils qw(uniq);
+use List::AllUtils qw(any uniq);
 use Log::Log4perl;
 use Log::Log4perl::Level;
 use Pod::Usage;
@@ -206,10 +206,10 @@ sub run {
                    join(", ", map { $_->name } $pipedb->snpset->all), "]");
   }
   if ($chip_design) {
-    unless (grep { /^$chip_design$/msx } @chip_designs) {
-        $log->logcroak("Invalid chip design '",
-                       $chip_design, "'. Valid designs are: [ ",
-                       join(", ", @chip_designs), "]");
+    unless (any { $chip_design eq $_ } @chip_designs) {
+      $log->logcroak("Invalid chip design '",
+                     $chip_design, "'. Valid designs are: [ ",
+                     join(", ", @chip_designs), "]");
     }
   }
   else {

--- a/src/perl/bin/ready_samples.pl
+++ b/src/perl/bin/ready_samples.pl
@@ -7,6 +7,7 @@ package main;
 use strict;
 use warnings;
 use Getopt::Long;
+use List::AllUtils qw(any);
 use Log::Log4perl qw(:easy);
 use Pod::Usage;
 
@@ -78,7 +79,7 @@ sub run {
         die "Failed to select sample state '$select': invalid state\n";
       }
 
-      if (grep { $state->name eq $_->name } $sample->states) {
+      if (any { $state->name eq $_->name } $sample->states) {
         print $out $sample->name, "\n";
         describe_sample($sample, \*STDERR) if $verbose;
       }
@@ -102,7 +103,7 @@ sub run {
                die "Failed to remove sample state '$remove': invalid state\n";
              }
 
-             if (grep { $state->name eq $_->name } $sample->states) {
+             if (any { $state->name eq $_->name } $sample->states) {
                $sample->remove_from_states($state);
              }
            }
@@ -113,7 +114,7 @@ sub run {
                die "Failed to add sample state '$add': invalid state\n";
              }
 
-             unless (grep { $state->name eq $_->name } $sample->states) {
+             unless (any { $state->name eq $_->name } $sample->states) {
                $sample->add_to_states($state);
              }
            }

--- a/src/perl/bin/run_qc.pl
+++ b/src/perl/bin/run_qc.pl
@@ -102,7 +102,9 @@ $dbPath = verifyAbsPath($dbPath);
 $outDir ||= "./qc";
 $mafHet ||= 0;
 if (not -e $outDir) { mkdir($outDir); }
-elsif (not -w $outDir) { croak "Cannot write to output directory ".$outDir; }
+elsif (not -w $outDir) {
+ die "Cannot write to output directory $outDir\n";
+}
 $outDir = abs_path($outDir);
 $title ||= getDefaultTitle($outDir); 
 my $texIntroPath = defaultTexIntroPath($iniPath);
@@ -145,7 +147,7 @@ sub getDefaultTitle {
     # default title made up of last 2 non-empty items in path
     my $outDir = shift;
     $outDir = abs_path($outDir);
-    my @terms = split(/\//, $outDir);
+    my @terms = split /\//msx, $outDir;
     my $total = @terms;
     my $title = $terms[$total-2]."/".$terms[$total-1];
     return $title;
@@ -215,7 +217,9 @@ sub processPlinkPrefix {
 	$plinkPrefix = getcwd()."/".$plinkPrefix;
     }
     my $ok = checkPlinkBinaryInputs($plinkPrefix);
-    unless ($ok) { die "Cannot read plink binary inputs for prefix $plinkPrefix"; }
+    unless ($ok) {
+      die "Cannot read plink binary inputs for prefix $plinkPrefix\n";
+    }
     return $plinkPrefix;
 }
 
@@ -223,8 +227,7 @@ sub verifyAbsPath {
     my $path = shift;
     my $cwd = getcwd();
     unless (-e $path) { 
-	croak "Path '$path' does not exist relative to current ".
-	    "directory '$cwd'"; 
+      die "Path '$path' does not exist relative to current directory '$cwd'\n";
     }
     $path = abs_path($path);
     return $path;
@@ -247,7 +250,7 @@ sub run_qc_wip {
   my $cmd = $script." ".join(" ", @args);
   my $result = system($cmd);
   if ($result!=0) {
-    croak "Command finished with non-zero exit status: \"$cmd\"";
+    die qq(Command finished with non-zero exit status: "$cmd"\n);
   }
 
 }
@@ -265,7 +268,7 @@ sub run {
 	);
     my $genderCmd = "$Bin/check_xhet_gender.pl --input=$plinkPrefix --output-dir=$outDir";
     if (!defined($runName)) {
-	croak "Must supply pipeline run name for database gender update";
+      die "Must supply pipeline run name for database gender update\n";
     }
     $genderCmd.=" --dbfile=".$dbPath." --run=".$runName; 
     push(@cmds, $genderCmd);
@@ -289,7 +292,7 @@ sub run {
     foreach my $cmd (@cmds) {
         my $result = system($cmd); 
         if ($result!=0) {
-            croak "Command finished with non-zero exit status: \"$cmd\""; 
+          die qq("Command finished with non-zero exit status: "$cmd"\n);
         }
     }
     ### run identity check ###
@@ -300,7 +303,9 @@ sub run {
         plink_path => $plinkPrefix,
     )->run_identity_check();
     my $idJson = $outDir.'/'.$fileNames{'id_json'};
-    if (!(-e $idJson)) { croak "Identity JSON file '$idJson' does not exist!"; }
+    if (!(-e $idJson)) {
+      die "Identity JSON file '$idJson' does not exist!\n";
+    }
     ### collate inputs, write JSON and CSV ###
     my $csvPath = $outDir."/pipeline_summary.csv";
     my $statusJson = $outDir."/qc_results.json";
@@ -333,8 +338,8 @@ sub run {
     foreach my $cmd (@cmds) { 
         my $result = system($cmd); 
         if ($result!=0) { 
-            croak "Command finished with non-zero exit status: \"$cmd\""; 
-        } 
+           die qq("Command finished with non-zero exit status: "$cmd"\n);
+        }
     }
     ### create PDF report
     my $texPath = $outDir."/pipeline_summary.tex";

--- a/src/perl/bin/sample_intensities.pl
+++ b/src/perl/bin/sample_intensities.pl
@@ -17,7 +17,7 @@ use WTSI::NPG::Genotyping::Database::Pipeline;
 our $VERSION = '';
 our $WTSI_NAMESPACE = 'wtsi';
 our $DEFAULT_INI = $ENV{HOME} . "/.npg/genotyping.ini";
-our $ID_REGEX = qr/^[A-Za-z0-9-._]{4,}$/msx;
+our $ID_REGEX = qr/^[\w.-]{4,}$/msx;
 
 Log::Log4perl->easy_init($ERROR);
 
@@ -159,7 +159,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2012 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2012, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/bin/set_irods_group_access.pl
+++ b/src/perl/bin/set_irods_group_access.pl
@@ -7,6 +7,7 @@ package main;
 use strict;
 use warnings;
 use Getopt::Long;
+use List::AllUtils qw(any);
 use Log::Log4perl;
 use Log::Log4perl::Level;
 use Pod::Usage;
@@ -57,7 +58,7 @@ sub run {
   $access_level ||= 'read';
 
   my @valid_levels = ('null', 'read', 'write', 'own');
-  unless (grep { /^$access_level$/msx } @valid_levels) {
+  unless (any { $access_level eq $_ } @valid_levels) {
     pod2usage(-msg => "Invalid --access argument '$access_level'. Must be one of [" .
               join(', ', @valid_levels) . "]" ,
               -exitval => 2);

--- a/src/perl/bin/set_irods_group_access.pl
+++ b/src/perl/bin/set_irods_group_access.pl
@@ -56,7 +56,7 @@ sub run {
   $access_level ||= 'read';
 
   my @valid_levels = ('null', 'read', 'write', 'own');
-  unless (grep { /^$access_level$/ } @valid_levels) {
+  unless (grep { /^$access_level$/msx } @valid_levels) {
     pod2usage(-msg => "Invalid --access argument '$access_level'. Must be one of [" .
               join(', ', @valid_levels) . "]" ,
               -exitval => 2);
@@ -87,8 +87,8 @@ sub run {
 
   while (my $study_id = <$in>) {
     chomp($study_id);
-    $study_id =~ s/^\s+//;
-    $study_id =~ s/\s+$//;
+    $study_id =~ s/^\s+//msx;
+    $study_id =~ s/\s+$//msx;
 
     next unless $study_id;
 
@@ -197,7 +197,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/bin/update_infinium_metadata.pl
+++ b/src/perl/bin/update_infinium_metadata.pl
@@ -10,6 +10,7 @@ use Getopt::Long;
 use Log::Log4perl;
 use Log::Log4perl::Level;
 use Pod::Usage;
+use Try::Tiny;
 
 use WTSI::NPG::Database::Warehouse;
 use WTSI::NPG::Genotyping::Infinium::InfiniumDataObject;
@@ -120,7 +121,7 @@ sub run {
   }
 
   my $total = scalar @infinium_data;
-  my $updated = 0;
+  my $num_updated = 0;
 
   if ($stdio) {
     $log->info("Updating metadata on $updated/$total data objects in ",
@@ -131,27 +132,24 @@ sub run {
   }
 
   foreach my $data_object (@infinium_data) {
-    eval {
+    try {
       my $ido = WTSI::NPG::Genotyping::Infinium::InfiniumDataObject->new
         ($irods, $data_object);
       $ido->update_secondary_metadata($ssdb);
-      ++$updated;
-    };
 
-    if ($@) {
-      $log->error("Failed to update metadata for '$data_object': ", $@);
-    }
-    else {
-      $log->info("Updated metadata for '$data_object': $updated of $total");
-    }
+      $num_updated++;
+      $log->info("Updated metadata for '$data_object': $num_updated of $total");
+    } catch {
+      $log->error("Failed to update metadata for '$data_object': ", $_);
+    };
   }
 
   if ($stdio) {
-    $log->info("Updated metadata on $updated/$total data objects in ",
+    $log->info("Updated metadata on $num_updated/$total data objects in ",
                "file list");
   }
   else {
-    $log->info("Updated metadata on $updated/$total data objects in ",
+    $log->info("Updated metadata on $num_updated/$total data objects in ",
                "'$publish_dest'");
   }
 

--- a/src/perl/bin/update_sequenom_qc_metadata.pl
+++ b/src/perl/bin/update_sequenom_qc_metadata.pl
@@ -11,6 +11,7 @@ use Getopt::Long;
 use Log::Log4perl;
 use Log::Log4perl::Level;
 use Pod::Usage;
+use Try::Tiny;
 
 use WTSI::NPG::Genotyping::Database::SNP;
 use WTSI::NPG::Genotyping::Sequenom::AssayDataObject;
@@ -148,7 +149,7 @@ sub run {
   }
 
   my $total = scalar @sequenom_data;
-  my $updated = 0;
+  my $num_updated = 0;
 
   if ($stdio) {
     $log->info("Updating metadata on $updated/$total data objects in ",
@@ -159,27 +160,25 @@ sub run {
   }
 
   foreach my $data_object (@sequenom_data) {
-    eval {
+    try {
       my $sdo = WTSI::NPG::Genotyping::Sequenom::AssayDataObject->new
         ($irods, $data_object);
       $sdo->update_qc_metadata($snpdb);
-      ++$updated;
-    };
 
-    if ($@) {
-      $log->error("Failed to update QC metadata for '$data_object': ", $@);
-    }
-    else {
-      $log->info("Updated QC metadata for '$data_object': $updated of $total");
-    }
+      $num_updated++;
+      $log->info("Updated QC metadata for '$data_object': ",
+                 "$num_updated of $total");
+    } catch {
+      $log->error("Failed to update QC metadata for '$data_object': ", $_);
+    };
   }
 
   if ($stdio) {
-    $log->info("Updated QC metadata on $updated/$total data objects in ",
+    $log->info("Updated QC metadata on $num_updated/$total data objects in ",
                "file list");
   }
   else {
-    $log->info("Updated QC metadata on $updated/$total data objects in ",
+    $log->info("Updated QC metadata on $num_updated/$total data objects in ",
                "'$publish_dest'");
   }
 

--- a/src/perl/bin/write_snp_metadata.pl
+++ b/src/perl/bin/write_snp_metadata.pl
@@ -1,7 +1,7 @@
 #!/software/bin/perl
 
 #
-# Copyright (c) 2013 Genome Research Ltd. All rights reserved.
+# Copyright (C) 2013, 2015 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -78,18 +78,18 @@ sub readWriteManifest {
 	if ($verbose && $i % 100_000 == 0) { print "$i lines read.\n"; }
 	chomp;
 	my %snp;
-        my @fields = split /,/;
+        my @fields = split /,/msx;
         foreach my $key (qw/name chromosome position norm_id/) {
             $snp{$key} = $fields[$indices{$key}];
         }
         my $alleles = $fields[$indices{'snp'}];
-        $alleles =~ s/\W//g; # remove nonword characters
+        $alleles =~ s/\W//msxg; # remove nonword characters
         my @alleles = split('', $alleles);
         if (@alleles!=2) { 
             $log->logcroak("Failed to find 2 alleles at manifest line ".$i."\n"); 
         }
         foreach my $allele (@alleles) {
-            if ($allele !~ /[A-Z]/) { # may include letters other than ACGT
+            if ($allele !~ /[[:upper:]]/msx) { # may include letters other than ACGT
                 $log->logcroak("Invalid allele character at manifest line ".$i."\n");
             }
         }
@@ -120,8 +120,8 @@ sub splitManifest {
         $i++;
         if ($verbose && $i % 100_000 == 0) { print "$i lines read.\n"; }
 	if ($i == 1) { next; } # first line is header
-	$_ =~ s/\s+$//g; # remove whitespace (including \r) from end of line
-	my @fields = split /,/;
+	$_ =~ s/\s+$//msxg; # remove whitespace (including \r) from end of line
+	my @fields = split /,/msx;
 	my $fields_found = @fields;
 	if ($fields_found != $expected_fields) {
 	    my $msg = "Incorrect number of fields in $inPath line $i; ".
@@ -169,7 +169,7 @@ sub writeSortedByPosition {
     open my $in, "<", $inPath || $log->logcroak("Cannot read input path $inPath");
     while (<$in>) {
 	push @input, $_;
-	my @fields = split /,/;
+	my @fields = split /,/msx;
 	my %snp;
 	$snp{'name'} = $fields[$nameIndex];
 	$snp{'position'} = $fields[$posIndex];

--- a/src/perl/lib/WTSI/NPG/Annotator.pm
+++ b/src/perl/lib/WTSI/NPG/Annotator.pm
@@ -171,7 +171,7 @@ sub make_type_metadata {
   }
 
   my ($basename, $dir, $suffix) = fileparse($file, @suffixes);
-  $suffix =~ s{^\.?}{}msxi;
+  $suffix =~ s{^[.]?}{}msxi;
 
   my @meta;
   if ($suffix) {

--- a/src/perl/lib/WTSI/NPG/Database/DBI.pm
+++ b/src/perl/lib/WTSI/NPG/Database/DBI.pm
@@ -78,3 +78,33 @@ sub is_connected {
 }
 
 1;
+
+__END__
+
+=head1 NAME
+
+WTSI::NPG::Genotyping::Database::DBI
+
+=head1 DESCRIPTION
+
+A Moose role providing utility methods for databases using DBI.
+
+=head1 AUTHOR
+
+Keith James <kdj@sanger.ac.uk>
+
+=head1 COPYRIGHT AND DISCLAIMER
+
+Copyright (C) 2015 Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut

--- a/src/perl/lib/WTSI/NPG/Database/DBIx.pm
+++ b/src/perl/lib/WTSI/NPG/Database/DBIx.pm
@@ -91,7 +91,7 @@ sub in_transaction {
       $self->logcroak("Attempted to use a closed connection")
     }
   } catch {
-    if ($_ =~ /Rollback failed/) {
+    if ($_ =~ m{Rollback failed}msx) {
       $self->logconfess("$_. Rollback failed! ",
                         "WARNING: data may be inconsistent.");
     } else {
@@ -103,3 +103,34 @@ sub in_transaction {
 }
 
 1;
+
+__END__
+
+=head1 NAME
+
+WTSI::NPG::Genotyping::Database::DBIx
+
+=head1 DESCRIPTION
+
+A Moose role providing utility methods for databases using
+DBIx::Class.
+
+=head1 AUTHOR
+
+Keith James <kdj@sanger.ac.uk>
+
+=head1 COPYRIGHT AND DISCLAIMER
+
+Copyright (C) 2015 Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut

--- a/src/perl/lib/WTSI/NPG/Database/MLWarehouse.pm
+++ b/src/perl/lib/WTSI/NPG/Database/MLWarehouse.pm
@@ -21,6 +21,34 @@ sub connect {
   return $self;
 }
 
+=head2 find_fluidigm_plate
+
+  Arg [1]    : string
+  Example    : $db->find_fluidigm_plate('Fluidigm plate barcode')
+  Description: Return plate details for an Infinium LIMS plate barcode
+               as a hashref with plate addresses as keys and values being
+               a further hashref for each sample having the following keys
+               and values:
+               { id_lims           => <Identifier of originating LIMS>,
+                 id_sample_lims    => <Sample identifier in LIMS>
+                 sanger_sample_id  => <WTSI sample name string>,
+                 consent_withdrawn => <boolean, true if now unconsented>,
+                 donor_id          => <SequenceScape donor id>,
+                 uuid              => <Sample UUID in LIMS,
+                 name              => <Sample name in LIMS>,
+                 common_name       => <Sample common name in LIMS>,
+                 supplier_name     => <Supplier provided name, may be undef>,
+                 gender            => <Supplier gender string>,
+                 cohort            => <Supplier cohort string>,
+                 control           => <Supplier control flag>,
+                 study_id          => <SequenceScape study id>,
+                 barcode           => <Plate barcode in LIMS>,
+                 map               => <Sample well address in LIMS> }
+  Returntype : hashref
+  Caller     : general
+
+=cut
+
 sub find_fluidigm_plate {
   my ($self, $fluidigm_barcode) = @_;
 
@@ -47,6 +75,36 @@ sub find_fluidigm_plate {
 
   return \%plate;
 }
+
+
+=head2 find_fluidigm_sample_by_plate
+
+  Arg [1]    : string plate barcode
+  Arg [2]    : string well address
+  Example    : $db->find_sample_by_fluidigm_plate('Fluidigm plate barcode', )
+  Description: Return plate details for an Infinium LIMS plate barcode
+               as a hashref with plate addresses as keys and values being
+               a further hashref for each sample having the following keys
+               and values:
+               { id_lims           => <Identifier of originating LIMS>,
+                 id_sample_lims    => <Sample identifier in LIMS>
+                 sanger_sample_id  => <WTSI sample name string>,
+                 consent_withdrawn => <boolean, true if now unconsented>,
+                 donor_id          => <SequenceScape donor id>,
+                 uuid              => <Sample UUID in LIMS,
+                 name              => <Sample name in LIMS>,
+                 common_name       => <Sample common name in LIMS>,
+                 supplier_name     => <Supplier provided name, may be undef>,
+                 gender            => <Supplier gender string>,
+                 cohort            => <Supplier cohort string>,
+                 control           => <Supplier control flag>,
+                 study_id          => <SequenceScape study id>,
+                 barcode           => <Plate barcode in LIMS>,
+                 map               => <Sample well address in LIMS> }
+  Returntype : hashref
+  Caller     : general
+
+=cut
 
 sub find_fluidigm_sample_by_plate {
   my ($self, $fluidigm_barcode, $well_address) = @_;
@@ -112,3 +170,31 @@ __PACKAGE__->meta->make_immutable;
 
 __END__
 
+=head1 NAME
+
+WTSI::NPG::Database::MLWarehouse
+
+=head1 DESCRIPTION
+
+A class for querying the WTSI multi-LIMS warehouse database to
+retrieve details of samples for genotyping analysis.
+
+=head1 AUTHOR
+
+Keith James <kdj@sanger.ac.uk>
+
+=head1 COPYRIGHT AND DISCLAIMER
+
+Copyright (C) 2015 Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut

--- a/src/perl/lib/WTSI/NPG/Database/Warehouse.pm
+++ b/src/perl/lib/WTSI/NPG/Database/Warehouse.pm
@@ -336,7 +336,7 @@ sub find_infinium_gex_sample {
   $map or $self->logconfess('The map argument was empty');
 
   my ($barcode_prefix, $barcode) =
-    $plate_barcode =~ /^([A-Z]{2})([0-9]+)[A-Z]$/;
+    $plate_barcode =~ m{^([[:upper:]]{2})(\d+)[[:upper:]]$}msx;
 
   defined $barcode_prefix or
      $self->logconfess("Invalid plate barcode '$plate_barcode': ",
@@ -675,7 +675,7 @@ __END__
 
 =head1 NAME
 
-WTSI::NPG::Genotyping::Database::Warehouse
+WTSI::NPG::Database::Warehouse
 
 =head1 DESCRIPTION
 
@@ -688,7 +688,8 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2012 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2012, 2013, 2014 Genome Research Limited. All Rights
+Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Expression/AnalysisPublisher.pm
+++ b/src/perl/lib/WTSI/NPG/Expression/AnalysisPublisher.pm
@@ -281,7 +281,7 @@ sub is_text_file {
 
   $self->debug("Detected file '$filename' to be ", join(' ', @result));
 
-  return (@result && $result[0] =~ m{^text\/plain});
+  return (@result && $result[0] =~ m{^text\/plain}msx);
 }
 
 __PACKAGE__->meta->make_immutable;
@@ -298,7 +298,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013, 2014, 2015 Genome Research Limited. All Rights
+Copyright (C) 2013, 2014, 2015 Genome Research Limited. All Rights
 Reserved.
 
 This program is free software: you can redistribute it and/or modify

--- a/src/perl/lib/WTSI/NPG/Expression/ChipLoadingManifest.pm
+++ b/src/perl/lib/WTSI/NPG/Expression/ChipLoadingManifest.pm
@@ -26,7 +26,7 @@ sub _validate_sample_id {
     $self->logcroak("Missing sample ID at line $line\n");
   }
 
-  unless ($sample_id =~ m{^\S+$}) {
+  unless ($sample_id =~ m{^\S+$}msx) {
     $self->logcroak("Invalid sample ID '$sample_id' at line $line\n");
   }
 
@@ -40,7 +40,7 @@ sub _validate_plate_id {
     $self->logcroak("Missing Supplier Plate ID at line $line\n");
   }
 
-  unless ($plate_id =~ m{^\S+$}) {
+  unless ($plate_id =~ m{^\S+$}msx) {
     $self->logcroak("Invalid Supplier plate ID '$plate_id' at line $line\n");
   }
 
@@ -54,7 +54,7 @@ sub _validate_well_id {
     $self->logcroak("Missing Supplier well ID at line $line\n");
   }
 
-  my ($row, $column) = $well_id =~ m{^([A-H])([1-9]+[0-2]?)$};
+  my ($row, $column) = $well_id =~ m{^([A-H])([1-9]+[0-2]?)$}msx;
   unless ($row && $column) {
     $self->logcroak("Invalid Supplier well ID '$well_id' at line $line\n");
   }
@@ -72,7 +72,7 @@ sub _validate_beadchip {
     $self->logcroak("Missing beadchip number at line $line\n");
   }
 
-  unless ($chip =~ m{^\d{10}$}) {
+  unless ($chip =~ m{^\d{10}$}msx) {
     $self->logcroak("Invalid beadchip number '$chip' at line $line\n");
   }
 
@@ -86,7 +86,7 @@ sub _validate_section {
     $self->logcroak("Missing beadchip section at line $line\n");
   }
 
-  unless ($section =~ m{^[A-Z]$}) {
+  unless ($section =~ m{^[[:upper:]]$}msx) {
     $self->logcroak("Invalid beadchip section '$section' at line $line\n");
   }
 
@@ -107,7 +107,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Expression/ChipLoadingManifestV1.pm
+++ b/src/perl/lib/WTSI/NPG/Expression/ChipLoadingManifestV1.pm
@@ -72,7 +72,7 @@ sub _parse_beadchip_table {
   while (my $line = <$fh>) {
     ++$n;
     chomp($line);
-    next if $line =~ m{^\s*$};
+    next if $line =~ m{^\s*$}msx;
 
     if ($in_sample_block) {
       my @row = map { trim($_) } split("\t", $line);
@@ -103,15 +103,15 @@ sub _parse_beadchip_table {
       }
     }
     else {
-      if ($line =~ m/BEADCHIP/) {
+      if ($line =~ m{BEADCHIP}msx) {
         $in_sample_block = 1;
         my @header = map { trim($_) } split("\t", $line);
         # Expected to be Sanger sample ID
-        $sample_id_col = firstidx { /SAMPLE ID/ } @header;
+        $sample_id_col = firstidx { m{SAMPLE\sID}msx } @header;
         # Expected to be chip number
-        $beadchip_col  = firstidx { /BEADCHIP/ } @header;
+        $beadchip_col  = firstidx { m{BEADCHIP}msx  } @header;
         # Expected to be chip section
-        $section_col = firstidx { /ARRAY/ } @header;
+        $section_col   = firstidx { m{ARRAY}msx     } @header;
       }
     }
   }
@@ -143,7 +143,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Expression/ChipLoadingManifestV2.pm
+++ b/src/perl/lib/WTSI/NPG/Expression/ChipLoadingManifestV2.pm
@@ -75,12 +75,12 @@ sub _parse_beadchip_table {
   while (my $line = <$fh>) {
     ++$n;
     chomp($line);
-    next if $line =~ m/^\s*$/;
+    next if $line =~ m{^\s*$}msx;
 
     if ($in_sample_block) {
       my @row = map { trim($_) } split("\t", $line);
 
-      if ($row[$end_of_data_col] =~ /^Kit Control$/i) {
+      if ($row[$end_of_data_col] =~ m{^Kit\sControl$}msxi) {
         last;
       }
       else {
@@ -98,19 +98,24 @@ sub _parse_beadchip_table {
       }
     }
     else {
-      if ($line =~ m/BEADCHIP/i) {
+      if ($line =~ m{BEADCHIP}msxi) {
         $in_sample_block = 1;
         my @header = map { trim($_) } split("\t", $line);
         # Expected to be Sanger sample ID
-        $sample_id_col = firstidx { /SAMPLE ID/i } @header;
+        $sample_id_col =
+          firstidx { m{SAMPLE\sID}msxi } @header;
         # Expected to be Sequencescape plate ID
-        $supplier_plate_id_col = firstidx { /SUPPLIER PLATE ID/i } @header;
+        $supplier_plate_id_col =
+          firstidx { m{SUPPLIER\sPLATE\sID}msxi } @header;
         # Expected to be Sequencescape welll map
-        $supplier_well_id_col = firstidx { /SUPPLIER WELL ID/i } @header;
+        $supplier_well_id_col =
+          firstidx { m{SUPPLIER\sWELL\sID}msxi } @header;
         # Expected to be chip number
-        $beadchip_col  = firstidx { /BEADCHIP/i } @header;
+        $beadchip_col  =
+          firstidx { m{BEADCHIP}msxi } @header;
         # Expected to be chip section
-        $section_col = firstidx { /ARRAY/i } @header;
+        $section_col =
+          firstidx { m{ARRAY}msxi } @header;
       }
     }
   }
@@ -142,7 +147,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Expression/ProfileAnnotation.pm
+++ b/src/perl/lib/WTSI/NPG/Expression/ProfileAnnotation.pm
@@ -39,19 +39,19 @@ sub is_valid {
   while (my $line = <$fh>) {
     chomp $line;
 
-    if ($line_num == 0 and $line =~ m{^\[Header\]}) {
+    if ($line_num == 0 and $line =~ m{^\[Header\]}msx) {
       $stanza = 1;
     }
 
-    if ($line_num == 1 and $line =~ m{^GSGX Version\s+1.9.0}) {
+    if ($line_num == 1 and $line =~ m{^GSGX\sVersion\s+1.9.0}msx) {
       $version = 1;
     }
 
-    if ($line_num == 7 and $line !~ m{^\[Control Probe Profile\]}) {
+    if ($line_num == 7 and $line !~ m{^\[Control\sProbe\sProfile\]}msx) {
       $profile = 1;
     }
 
-    if ($line_num == 8 and $line =~ m{^TargetID}) {
+    if ($line_num == 8 and $line =~ m{^TargetID}msx) {
       $target = 1;
     }
 
@@ -94,3 +94,25 @@ __PACKAGE__->meta->make_immutable;
 no Moose;
 
 1;
+
+__END__
+
+=head1 AUTHOR
+
+Keith James <kdj@sanger.ac.uk>
+
+=head1 COPYRIGHT AND DISCLAIMER
+
+Copyright (C) 2013, 2015 Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut

--- a/src/perl/lib/WTSI/NPG/Expression/Publisher.pm
+++ b/src/perl/lib/WTSI/NPG/Expression/Publisher.pm
@@ -188,8 +188,8 @@ sub _build_resultsets {
     my ($idat, $xml) = ('', '');
 
     foreach my $path (@fileset) {
-      if ($path =~ m{\.idat$}msi)   { $idat = $path }
-      elsif ($path =~ m{\.xml$}msi) { $xml = $path }
+      if    ($path =~ m{[.]idat$}msxi) { $idat = $path }
+      elsif ($path =~ m{[.]xml$}msxi)  { $xml  = $path }
       else {
         $self->warn("Failed to collate a resultset for beadchip ",
                     "'$beadchip' section '$section' because it ",
@@ -231,9 +231,9 @@ sub _build_filesets {
     my ($beadchip, $section, $suffix) =
       $filename =~ m{^
                      (\d{10})        # beadchip
-                     _([A-Z])        # beadchip section
+                     _([[:upper:]])  # beadchip section
                      _Grn            # channel, always Grn
-                     \.(\S+)         # suffix
+                     [.](\S+)         # suffix
                      $}msxi;
 
     unless ($beadchip && $section && $suffix) {
@@ -266,7 +266,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013, 2014, 2015 Genome Research Limited. All Rights
+Copyright (C) 2013, 2014, 2015 Genome Research Limited. All Rights
 Reserved.
 
 This program is free software: you can redistribute it and/or modify

--- a/src/perl/lib/WTSI/NPG/Expression/SampleProbeProfile.pm
+++ b/src/perl/lib/WTSI/NPG/Expression/SampleProbeProfile.pm
@@ -11,7 +11,6 @@ our $VERSION = '';
 with 'WTSI::DNAP::Utilities::Loggable', 'WTSI::NPG::Expression::Annotation',
   'WTSI::NPG::iRODS::Storable';
 
-our $PLATFORM = 'Illumina Inc. GenomeStudio version 1.9.0';
 our $NORMALISATION_HEADER_PROPERTY = 'Normalization';
 
 has 'normalisation_method' =>
@@ -50,15 +49,16 @@ sub is_valid {
   while (my $line = <$fh>) {
     chomp $line;
 
-    if ($line_num == 0 and $line =~ m{^Illumina Inc.\sGenomeStudio\sversion}) {
+    if ($line_num == 0 and
+        $line =~ m{^Illumina\sInc.\sGenomeStudio\sversion}msx) {
       $version = 1;
     }
 
-    if ($line_num == 1 and $line =~ m{^Normalization =}) {
+    if ($line_num == 1 and $line =~ m{^Normalization\s=}msx) {
       $norm = 1;
     }
 
-    if ($line_num == 2 and $line =~ m{^Array Content =}) {
+    if ($line_num == 2 and $line =~ m{^Array\sContent\s=}msx) {
       $content = 1;
     }
 
@@ -83,14 +83,14 @@ sub _build_normalisation_method {
 
   my $platform = <$fh>;
   chomp $platform;
-  unless ($platform =~ m{^$PLATFORM}) {
+  unless ($platform =~ m{^Illumina\sInc.\sGenomeStudio\sversion\s1.9.0}msx) {
     $self->warn("The Illumina platform '$platform' differs from the expected ",
-                "value of '$PLATFORM'.");
+                "value of 'Illumina Inc. GenomeStudio version 1.9.0'.");
   }
 
   my $normalisation = <$fh>;
   chomp $normalisation;
-  my ($prop, $method) = map { trim($_) } split /=/, $normalisation;
+  my ($prop, $method) = map { trim($_) } split /=/msx, $normalisation;
 
   unless (defined $prop   &&
           defined $method &&
@@ -130,3 +130,25 @@ __PACKAGE__->meta->make_immutable;
 no Moose;
 
 1;
+
+__END__
+
+=head1 AUTHOR
+
+Keith James <kdj@sanger.ac.uk>
+
+=head1 COPYRIGHT AND DISCLAIMER
+
+Copyright (C) 2013, 2015 Genome Research Limited. All Rights Reserved.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the Perl Artistic License or the GNU General
+Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+=cut

--- a/src/perl/lib/WTSI/NPG/Genotyping.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping.pm
@@ -31,7 +31,7 @@ sub base_dir {
   my ($vol, $dirs, $file) =
     File::Spec->splitpath($INC{"WTSI/NPG/Genotyping.pm"});
 
-  my ($base) = $dirs =~ m{^(.+)\blib};
+  my ($base) = $dirs =~ m{^(.+)\blib}msx;
 
   unless (defined $base) {
     my $cwd = getcwd();
@@ -121,7 +121,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2012 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2012, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General
@@ -132,9 +132,5 @@ This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 GNU General Public License for more details.
-
-=head1 VERSION
-
-  0.2.0
 
 =cut

--- a/src/perl/lib/WTSI/NPG/Genotyping/Database/Infinium.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Database/Infinium.pm
@@ -953,9 +953,9 @@ sub _choose_from_scans {
                           "undated; unable to choose which to use");
       }
 
-      @scans = sort { $b->{image_iso_date}
-                       cmp
-                      $a->{image_iso_date} } @dated_scans;
+      @scans = reverse sort { $a->{image_iso_date}
+                              cmp
+                              $b->{image_iso_date} } @dated_scans;
 
       # If the latest scan didn't pass, disregard it and look for an
       # older one that did pass

--- a/src/perl/lib/WTSI/NPG/Genotyping/Database/Pipeline.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Database/Pipeline.pm
@@ -40,7 +40,7 @@ has 'dbfile' =>
      my ($self) = @_;
 
      my $ds = $self->data_source;
-     my ($base, $file) = $ds =~ m/^(dbi:SQLite:dbname=)(.*)/;
+     my ($base, $file) = $ds =~ m{^(dbi:SQLite:dbname=)(.*)}msx;
      unless ($base && $file) {
        $self->logconfess("Failed to parse datasource string '$ds' in ",
                          $self->inifile);
@@ -64,7 +64,7 @@ sub BUILD {
   my ($self) = @_;
 
   my $ds = $self->data_source;
-  my ($base, $file) = $ds =~ m/^(dbi:SQLite:dbname=)(.*)/;
+  my ($base, $file) = $ds =~ m{^(dbi:SQLite:dbname=)(.*)}msx;
   unless ($base && $file) {
     $self->logconfess("Failed to parse datasource string '$ds' in ",
                       $self->inifile);
@@ -418,7 +418,7 @@ sub AUTOLOAD {
   my ($self) = @_;
   my $type = ref($self) or confess "$self is not an object";
 
-  return if $AUTOLOAD =~ /::DESTROY$/;
+  return if $AUTOLOAD =~ m{::DESTROY$}msx;
 
   if (!$self->is_connected) {
     $self->logconfess("$self is not connected");
@@ -432,7 +432,7 @@ sub AUTOLOAD {
   }
 
   my $method_name = $AUTOLOAD;
-  $method_name =~ s/.*://;
+  $method_name =~ s/.*://msx;
   unless (exists $lookup{$method_name} ) {
     $self->logconfess("An invalid method `$method_name' was called ",
                       "on an object of $type. Permitted methods are [",
@@ -471,7 +471,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2012 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2012, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/Database/Pipeline/Schema/Result/Piperun.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Database/Pipeline/Schema/Result/Piperun.pm
@@ -3,6 +3,7 @@ package WTSI::NPG::Genotyping::Database::Pipeline::Schema::Result::Piperun;
 
 use strict;
 use warnings;
+use Carp;
 
 use base 'DBIx::Class::Core';
 
@@ -43,7 +44,7 @@ sub validate_snpset {
   my ($self, $snpset) = @_;
 
   my @snpsets = map { $_->snpset } $self->datasets;
-  my @infinium_snpsets = grep { $_->name !~ m{sequenom|fluidigm}i } @snpsets;
+  my @infinium_snpsets = grep { $_->name !~ m{sequenom|fluidigm}msxi } @snpsets;
 
   my $valid = 1;
   if (@infinium_snpsets) {
@@ -71,7 +72,7 @@ sub validate_datasets {
 
   my @snpsets = map { $_->snpset } $self->datasets;
 
-  my @infinium_snpsets = grep { $_->name !~ m{sequenom|fluidigm}i } @snpsets;
+  my @infinium_snpsets = grep { $_->name !~ m{sequenom|fluidigm}msxi } @snpsets;
   my @snpset_names = map { $_->name } @infinium_snpsets;
 
   my $valid = 1;
@@ -90,7 +91,7 @@ sub validate_datasets {
 
     if (@mismatched) {
       $valid = 0;
-      warn "Invalid piperun; datasets have mixed SNP sets: [",
+      carp "Invalid piperun; datasets have mixed SNP sets: [",
         join(", ", @mismatched), "]";
     }
   }

--- a/src/perl/lib/WTSI/NPG/Genotyping/Database/Pipeline/Schema/Result/Piperun.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Database/Pipeline/Schema/Result/Piperun.pm
@@ -4,6 +4,7 @@ package WTSI::NPG::Genotyping::Database::Pipeline::Schema::Result::Piperun;
 use strict;
 use warnings;
 use Carp;
+use List::AllUtils qw(any);
 
 use base 'DBIx::Class::Core';
 
@@ -49,7 +50,7 @@ sub validate_snpset {
   my $valid = 1;
   if (@infinium_snpsets) {
     my $name = $snpset->name;
-    unless (grep { $_->name eq $name } @infinium_snpsets) {
+    unless (any { $_->name eq $name } @infinium_snpsets) {
       $valid = 0;
     }
   }

--- a/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/AssayResult.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/AssayResult.pm
@@ -150,7 +150,7 @@ sub compact_call {
   my ($self) = @_;
 
   my $compact = $self->converted_call;
-  $compact =~ s/://;
+  $compact =~ s/://msx;
 
   return $compact;
 }
@@ -275,7 +275,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2014, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/ExportFile.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/ExportFile.pm
@@ -215,12 +215,12 @@ sub _parse_fluidigm_table {
   while (my $line = <$fh>) {
     ++$line_num;
     chomp($line);
-    next if $line =~ m/^\s*$/;
+    next if $line =~ m{^\s*$}msx;
 
-    if ($line =~ /^Chip Run Info/) { $in_header = 1 }
-    if ($line =~ /^Experiment/)    { $in_header = 0 }
-    if ($line =~ /^ID/)            { $in_column_names = 1 }
-    if ($line =~ /^S[0-9]+\-[A-Z][0-9]+/) {
+    if ($line =~ m{^Chip\sRun\sInfo}msx) { $in_header = 1 }
+    if ($line =~ m{^Experiment}msx)    { $in_header = 0 }
+    if ($line =~ m{^ID}msx)            { $in_column_names = 1 }
+    if ($line =~ m{^S\d+\-[[:upper:]]\d+}msx) {
       $in_column_names = 0;
       $in_sample_block = 1;
     }
@@ -332,7 +332,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/ResultSet.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/ResultSet.pm
@@ -49,7 +49,7 @@ sub BUILD {
   }
 
   # find barcode (identical to directory name, by definition)
-  my @terms = split(/\//, $self->directory);
+  my @terms = split(/\//msx, $self->directory);
   if ($terms[-1] eq '') { pop @terms; } # in case of trailing / in path
   $self->_fluidigm_barcode(pop(@terms));
   # validate data subdirectory
@@ -94,7 +94,7 @@ Iain Bancarz <ib5@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/Illuminus.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Illuminus.pm
@@ -109,7 +109,7 @@ sub update_it_columns {
   while (my $line = <$in>) {
     chomp($line);
 
-    my @fields = split(/\t/, $line);
+    my @fields = split(/\t/msx, $line);
 
     for (my $i = 0; $i < scalar @annotation_columns; ++$i) {
       my $annot = shift @fields;
@@ -216,7 +216,7 @@ sub read_gt_column_names {
 
   Arg [1]    : input filehandle
   Arg [2]    : output filehandle
-  Arg [3]    : column separator
+  Arg [3]    : column separator (permitted are \s or \t)
   Arg [4]    : column offset (0-based)
   Arg [5]    : column group (number of data per column)
   Arg [6]    : arrayref of column indices
@@ -235,10 +235,25 @@ sub filter_gt_columns {
   my ($in, $out, $col_separator, $col_offset,
       $col_group, $indices, $op) = @_;
 
+  defined $col_separator or
+    confess 'A defined col_separator argument is required';
+
+  my $split_regex;
+  if ($col_separator eq ' ') {
+    $split_regex = qr{\s}msx;
+  }
+  elsif ($col_separator eq "\t") {
+    $split_regex = qr{\t}msx;
+  }
+  else {
+    confess "Invalid col_separator argument '$col_separator'. " .
+      "A single tab or space are permitted.";
+  }
+
   my $num_lines = 0;
   while (my $line = <$in>) {
     chomp($line);
-    my @fields = split(/$col_separator/, $line);
+    my @fields = split(/$split_regex/msx, $line);
 
     for (my $i = 0; $i < $col_offset; ++$i) {
       my $annotation_col = shift @fields;
@@ -297,9 +312,9 @@ sub write_gt_calls {
     chomp($probs_str);
 
     my ($call_name, $call_pos, $call_alleles, @calls) =
-      split(/\s+/, $calls_str);
+      split(/\s+/msx, $calls_str);
     my ($prob_name, $prob_pos, $prob_alleles, @probs) =
-      split(/\s+/, $probs_str);
+      split(/\s+/msx, $probs_str);
 
     unless ($call_name eq $prob_name &&
             $call_pos == $prob_pos &&
@@ -368,7 +383,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2012 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2012, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/Infinium/AnalysisPublisher.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Infinium/AnalysisPublisher.pm
@@ -5,6 +5,7 @@ package WTSI::NPG::Genotyping::Infinium::AnalysisPublisher;
 
 use File::Spec;
 use Moose;
+use Try::Tiny;
 
 use WTSI::NPG::iRODS;
 use WTSI::NPG::Publisher;
@@ -120,7 +121,7 @@ sub publish {
   my $num_samples = 0;
   my $num_objects = 0;
 
-  eval {
+  try {
     my @analysis_meta;
     push(@analysis_meta, $self->make_analysis_metadata(\@project_titles));
     push(@analysis_meta, $self->make_creation_metadata($self->affiliation_uri,
@@ -221,18 +222,15 @@ sub publish {
 
     my @groups = $analysis_coll->expected_groups;
     $analysis_coll->set_content_permissions('read', @groups);
-  };
 
-  if ($@) {
-    $self->error("Failed to publish: ", $@);
-    undef $analysis_uuid;
-  }
-  else {
     $self->info("Published '", $self->analysis_directory, "' to '",
                 $analysis_coll->str, "' and cross-referenced $num_objects ",
                 "data objects for $num_samples samples in ",
                 "$num_projects projects");
-  }
+  } catch {
+    $self->error("Failed to publish: ", $@);
+    undef $analysis_uuid;
+  };
 
   return $analysis_uuid;
 }

--- a/src/perl/lib/WTSI/NPG/Genotyping/Infinium/Publisher.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Infinium/Publisher.pm
@@ -333,9 +333,9 @@ sub _build_resultsets {
       my ($gtc, $red, $grn) = ('', '', '');
 
       foreach my $path (@fileset) {
-        if ($path =~ m{_Red\.idat$}msi)    { $red = $path }
-        elsif ($path =~ m{_Grn\.idat$}msi) { $grn = $path }
-        elsif ($path =~ m{\.gtc}msi)       { $gtc = $path }
+        if    ($path =~ m{_Red[.]idat$}msxi) { $red = $path }
+        elsif ($path =~ m{_Grn[.]idat$}msxi) { $grn = $path }
+        elsif ($path =~ m{[.]gtc}msxi)       { $gtc = $path }
         else {
           $self->warn("Failed to collate a resultset for beadchip ",
                       "'$beadchip' section '$section' because it ",
@@ -417,7 +417,7 @@ sub _build_filesets {
                      (\d{10,11})        # beadchip
                      _(R\d{2}C\d{2}) # beadchip section
                      _?(Red|Grn)?    # channel (idat only)
-                     \.(\S+)         # suffix
+                     [.](\S+)         # suffix
                      $}msxi;
 
     unless ($beadchip && $section && $suffix) {
@@ -447,7 +447,7 @@ sub _validate_file {
   my ($self, $file, $publish_dest) = @_;
   # gather information on source and destination files, if available
   my ($file_exists, $listing, $valid_meta, $file_md5, $irods_md5);
-  unless ($publish_dest =~ /\/$/) { $publish_dest .= '/'; }
+  unless ($publish_dest =~ m{\/$}msx) { $publish_dest .= '/'; }
   if (-e $file) {
       $file_exists = 1;
       $file_md5 = $self->irods->md5sum($file);

--- a/src/perl/lib/WTSI/NPG/Genotyping/Infinium/Publisher.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Infinium/Publisher.pm
@@ -3,9 +3,11 @@ use utf8;
 
 package WTSI::NPG::Genotyping::Infinium::Publisher;
 
-use List::AllUtils qw(sum);
 use File::Basename;
+use List::AllUtils qw(sum);
 use Moose;
+use Try::Tiny;
+
 use WTSI::NPG::Genotyping::Infinium::InfiniumDataObject;
 use WTSI::NPG::Genotyping::Infinium::ResultSet;
 use WTSI::NPG::iRODS;
@@ -52,45 +54,11 @@ has 'ss_warehouse_db' =>
    isa      => 'Object',
    required => 1);
 
-
 sub BUILD {
   my ($self) = @_;
 
   # Make our irods handle use our logger by default
   $self->irods->logger($self->logger);
-}
-
-sub dry_run {
-  my ($self, $publish_dest, $output) = @_;
-  return $self->dry_run_samples($publish_dest, $output);
-}
-
-sub dry_run_samples {
-  my ($self, $publish_dest, $output) = @_;
-  $publish_dest = $self->_validate_publish_dest($publish_dest);
-  # find out how many files are ready to be published:
-  # ie. source exists, and data exists in Infinium LIMS
-  my $num_ready = 0;
-  my $total = scalar @{$self->resultsets} * 3;
-  $self->info("Starting dry run for $total Infinium files");
-  my $out = $self->_open_output_handle($output);
-  foreach my $resultset (@{$self->resultsets}) {
-    my $idat_ok = $self->_dryrun_idat_files($resultset);
-    my $gtc_ok = $self->_dryrun_gtc_file($resultset);
-    if ($idat_ok + $gtc_ok == 3) {
-      foreach my $file ($resultset->grn_idat_file,
-                        $resultset->red_idat_file,
-                        $resultset->gtc_file) {
-        $num_ready++;
-        if ($out) { print $out $file."\n"; }
-      }
-    }
-  }
-  if ($out && $output ne '-') {
-    close $out || $self->logcroak("Cannot close output '$output'");
-  }
-  $self->info("$num_ready of $total Infinium files are ready to publish.");
-  return $num_ready;
 }
 
 sub publish {
@@ -101,7 +69,12 @@ sub publish {
 sub publish_samples {
   my ($self, $publish_dest) = @_;
 
-  $publish_dest = $self->_validate_publish_dest($publish_dest);
+  defined $publish_dest or
+    $self->logconfess('A defined publish_dest argument is required');
+  $publish_dest eq '' and
+    $self->logconfess('A non-empty publish_dest argument is required');
+
+  $publish_dest = File::Spec->canonpath($publish_dest);
 
   my $num_published = 0;
   my $total = sum map { $_->size } @{$self->resultsets};
@@ -123,101 +96,6 @@ sub publish_samples {
   return $num_published;
 }
 
-sub validate {
-  my ($self, $publish_dest, $output) = @_;
-  return $self->validate_samples($publish_dest, $output);
-}
-
-sub validate_samples {
-  my ($self, $publish_dest, $output) = @_;
-  $publish_dest = $self->_validate_publish_dest($publish_dest);
-  my $total = scalar @{$self->resultsets} * 3;
-  my $num_valid = 0;
-  $self->debug("Starting to validate $total Infinium files");
-  my $out = $self->_open_output_handle($output);
-  my @descriptions = _descriptions();
-  foreach my $resultset (@{$self->resultsets}) {
-    foreach my $file ($resultset->grn_idat_file,
-                      $resultset->red_idat_file,
-                      $resultset->gtc_file) {
-      my ($file, $irods_file, $status) =
-        @{$self->_validate_file($file, $publish_dest)};
-      if ($status == 0) { $num_valid++; }
-      my @fields = ($file, $irods_file, $status, $descriptions[$status]);
-      if ($out) { print $out join("\t", @fields)."\n"; }
-    }
-  }
-  if ($out && $output ne '-') {
-      close $out || $self->logconfess("Cannot close output '$output'");
-  }
-  return $num_valid;
-}
-
-sub _dryrun_gtc_file {
-  my ($self, $resultset) = @_;
-  my $gtc_file = $resultset->gtc_file;
-  my ($vol, $dirs, $gtc_filename) = File::Spec->splitpath($gtc_file);
-  my $if_sample;
-  my $num_ready = 0;
-  if (!(-e $gtc_file)) {
-    $self->warn("Input GTC file $gtc_file does not exist");
-  } else {
-    eval {
-      $if_sample = $self->infinium_db->find_called_sample($gtc_filename);
-    };
-    if (!($if_sample) || $@) {
-      $self->warn("Query error for GTC $gtc_filename in Infinium LIMS");
-    } else {
-      $self->debug("File $gtc_filename OK for publication");
-      $num_ready = 1;
-    }
-  }
-  return $num_ready;
-}
-
-sub _dryrun_idat_files {
-  my ($self, $resultset) = @_;
-  my $grn_file = $resultset->grn_idat_file;
-  my $red_file = $resultset->red_idat_file;
-  my $num_ready = 0;
-  my $missing_files = 0;
-  foreach my $file ($red_file, $grn_file) {
-    if (!(-e $file)) {
-      $self->warn("Input IDAT file $file does not exist");
-      $missing_files = 1;
-    }
-  }
-  my ($if_sample, $vol, $dirs, $grn_name, $red_name);
-  ($vol, $dirs, $red_name) = File::Spec->splitpath($red_file);
-  ($vol, $dirs, $grn_name) = File::Spec->splitpath($grn_file);
-  eval {
-    $if_sample = $self->infinium_db->find_scanned_sample($red_name);
-  };
-  if (!($if_sample) || $@) {
-    $self->warn("Query error for IDAT $red_name in Infinium LIMS");
-    $self->warn("Cannot publish IDAT $grn_name due to LIMS error");
-  } elsif ($missing_files==0) {
-    $self->debug("File $red_name OK for publication");
-    $self->debug("File $grn_name OK for publication");
-    $num_ready = 2;
-  }
-  return $num_ready;
-}
-
-sub _open_output_handle {
-  my ($self, $output) = @_;
-  my $out;
-  if ($output) {
-    if ($output eq '-') {
-      $out = *STDOUT;
-    } else {
-      open $out, ">", $output ||
-        $self->logcroak("Cannot open output '$output'");
-    }
-  }
-  return $out;
-}
-
 sub _publish_gtc_file {
   my ($self, $resultset, $publish_dest) = @_;
 
@@ -229,17 +107,13 @@ sub _publish_gtc_file {
   my $if_sample = $self->infinium_db->find_called_sample($gtc_filename);
 
   if ($if_sample) {
-    eval {
+    try {
       $self->_publish_file($gtc_file, $if_sample, $publish_dest);
-      ++$num_published;
-    };
-
-    if ($@) {
-      $self->error("Failed to publish '$gtc_file' to '$publish_dest': ", $@);
-    }
-    else {
+      $num_published++;
       $self->info("Published '$gtc_file' to '$publish_dest'");
-    }
+    } catch {
+      $self->error("Failed to publish '$gtc_file' to '$publish_dest': ", $_);
+    };
   }
   else {
     $self->warn("Failed to find the sample for '$gtc_filename' ",
@@ -262,17 +136,13 @@ sub _publish_idat_files {
 
   if ($if_sample) {
     foreach my $file ($grn_file, $red_file) {
-      eval {
+      try {
         $self->_publish_file($file, $if_sample, $publish_dest);
-        ++$num_published;
-      };
-
-      if ($@) {
-        $self->error("Failed to publish '$file' to '$publish_dest': ", $@);
-      }
-      else {
+        $num_published++;
         $self->info("Published '$file' to '$publish_dest'");
-      }
+      } catch {
+        $self->error("Failed to publish '$file' to '$publish_dest': ", $_);
+      };
     }
   }
   else {
@@ -434,73 +304,6 @@ sub _build_filesets {
   }
 
   return \%filesets;
-}
-
-sub _descriptions {
-  # return a list of upload status descriptions
-  my @descriptions = qw/UPLOAD_OK SOURCE_MISSING DEST_MISSING
-                        METADATA_MD5_ERROR SOURCE_MD5_ERROR/;
-  return @descriptions;
-}
-
-sub _validate_file {
-  my ($self, $file, $publish_dest) = @_;
-  # gather information on source and destination files, if available
-  my ($file_exists, $listing, $valid_meta, $file_md5, $irods_md5);
-  unless ($publish_dest =~ m{\/$}msx) { $publish_dest .= '/'; }
-  if (-e $file) {
-      $file_exists = 1;
-      $file_md5 = $self->irods->md5sum($file);
-      $publish_dest .= $self->irods->hash_path($file).'/'.fileparse($file);
-      $listing = eval { $self->irods->list_object($publish_dest) };
-      if ($listing) {
-        $valid_meta = eval {
-          $self->irods->validate_checksum_metadata($publish_dest);
-        };
-        $irods_md5 = eval {
-          $self->irods->calculate_checksum($publish_dest);
-        };
-        if (!defined($valid_meta)) {
-          $self->warn("Unable to validate metadata: ", $@);
-        } elsif (!defined($irods_md5)) {
-          $self->warn("Unable to calculate iRODS checksum: ", $@);
-        }
-      }
-  } else {
-      $publish_dest = 'UNKNOWN';
-  }
-  $self->debug("Validating publication of $file to $publish_dest");
-  # assign status to file
-  my $status = 0;
-  if (! $file_exists) {
-    $status = 1;
-  } elsif (! $listing) {
-    $status = 2;
-  } elsif (! $valid_meta) {
-    $status = 3;
-  } elsif ($file_md5 ne $irods_md5) {
-    $status = 4;
-  }
-  if ($status==0) {
-      $self->info("Validation OK: file ", $file, " status ", $status);
-  } else {
-      $self->info("Validation FAIL: file ", $file, " status ", $status);
-  }
-  return [$file, $publish_dest, $status];
-}
-
-sub _validate_publish_dest {
-  my ($self, $publish_dest) = @_;
-
-  defined $publish_dest or
-    $self->logconfess('A defined publish_dest argument is required');
-
-  $publish_dest eq '' and
-    $self->logconfess('A non-empty publish_dest argument is required');
-
-  $publish_dest = File::Spec->canonpath($publish_dest);
-
-  return $publish_dest;
 }
 
 __PACKAGE__->meta->make_immutable;

--- a/src/perl/lib/WTSI/NPG/Genotyping/Infinium/ResultSet.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Infinium/ResultSet.pm
@@ -82,7 +82,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013, 2015 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/Plink.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Plink.pm
@@ -115,7 +115,7 @@ sub _update_placeholder {
     my $n = 0;
     while (my $line = <$in>) {
 	chomp($line);
-	my ($family, $individual, $paternal, $maternal, $sex, $phenotype) = split /\s+/, $line;
+	my ($family, $individual, $paternal, $maternal, $sex, $phenotype) = split /\s+/msx, $line;
 	my $updated = 0;
 	my @output = ($family, $individual);
 	my @fields = ($paternal, $maternal, $sex, $phenotype);
@@ -156,7 +156,7 @@ sub _update_snp_locations {
   while (my $line = <$in>) {
     chomp($line);
     my ($chr, $snp_name, $genetic_pos, $physical_pos, $allele1, $allele2) =
-      split /\s+/, $line;
+      split /\s+/msx, $line;
 
     unless (exists $locations->{$snp_name}) {
       confess "Failed to update the location of SNP '$snp_name'; " .
@@ -189,7 +189,7 @@ sub _update_sample_genders {
     chomp($line);
 
     my ($family_id, $individual_id, $paternal_id,
-		$maternal_id, $gender, $phenotype) = split /\s+/, $line;
+		$maternal_id, $gender, $phenotype) = split /\s+/msx, $line;
 
     unless (exists $genders->{$family_id}) {
       confess "Failed to update the gender of '$family_id'; " .
@@ -215,7 +215,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2012 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2012, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/QC/Collation.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/QC/Collation.pm
@@ -86,10 +86,10 @@ sub appendNull {
 sub bySampleName {
     # comparison function for sorting samples in getSampleInfo
     # if in plate_well_id format, sort by id; otherwise use standard sort
-    if ($a =~ /[A-Za-z0-9]+_[A-Za-z0-9]+_[A-Za-z0-9]+/ &&
-            $b =~ /[A-Za-z0-9]+_[A-Za-z0-9]+_[A-Za-z0-9]+/) {
-        my @termsA = split(/_/, $a);
-        my @termsB = split(/_/, $b);
+    if ($a =~ m{[[:alnum:]]+_[[:alnum:]]+_[[:alnum:]]+}msx &&
+        $b =~ m{[[:alnum:]]+_[[:alnum:]]+_[[:alnum:]]+}msx) {
+        my @termsA = split /_/msx, $a;
+        my @termsB = split /_/msx, $b;
         return $termsA[-1] cmp $termsB[-1];
     } else {
         return $a cmp $b;

--- a/src/perl/lib/WTSI/NPG/Genotyping/QC/GenderCheck.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/QC/GenderCheck.pm
@@ -3,7 +3,7 @@
 # July 2012
 
 #
-# Copyright (c) 2012 Genome Research Ltd. All rights reserved.
+# Copyright (C) 2012, 2015 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -124,9 +124,9 @@ sub processOptions {
             croak "ERROR: Input format must be one of: ".
                 "$textFormat, $jsonFormat, $plinkFormat";
         }
-    } elsif ($input =~ /\.txt$/) { 
+    } elsif ($input =~ m{[.]txt$}msx) {
         $inputFormat = $textFormat; 
-    } elsif ($input =~ /\.json$/) {
+    } elsif ($input =~ m{[.]json$}msx) {
         $inputFormat = $jsonFormat;
     } else {
         $inputFormat = $plinkFormat; 
@@ -321,7 +321,7 @@ sub writeSampleXhetTemp {
     my @header = qw/sample xhet/;
     print $fh join("\t", @header)."\n";
     if ($total != @xhets) { 
-        die "Name and xhet list arguments of different length: $!";  
+        die "Name and xhet list arguments of different length: $!\n";
     }
     for (my $i=0;$i<$total;$i++) {
         print $fh "$names[$i]\t$xhets[$i]\n";
@@ -384,7 +384,7 @@ sub readGenderOutput {
     my $inPath = shift;
     open my $in, "<", $inPath;
     my %genders;
-    if ($inPath =~ /\.txt$/) {
+    if ($inPath =~ m{[.]txt$}msx) {
 	my $first = 1;
 	while (<$in>) {
 	    if ($first) { $first = 0; next; } # skip headers
@@ -392,7 +392,7 @@ sub readGenderOutput {
 	    my ($sample, $gender) = ($words[0], $words[2]); # fields are: name, xhet, inferred, supplied
 	    $genders{$sample} = $gender;
 	}
-    } elsif ($inPath =~ /\.json$/) {
+    } elsif ($inPath =~ m{[.]json$}msx) {
 	my @lines = ();
 	while (<$in>) {
 	    chomp;

--- a/src/perl/lib/WTSI/NPG/Genotyping/QC/Identity.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/QC/Identity.pm
@@ -3,7 +3,7 @@
 # March 2014
 
 #
-# Copyright (c) 2014 Genome Research Ltd. All rights reserved.
+# Copyright (C) 2014, 2015 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -191,7 +191,7 @@ sub equivalent {
     # allow no-call genotypes (represented by NN or 0)
     my $inputOK = 1;
     foreach my $gt ($gt0, $gt1) {
-	if ($gt && $gt ne 'NN' && (length($gt)!=2 || $gt =~ /[^ACGT]/)) { 
+	if ($gt && $gt ne 'NN' && (length($gt)!=2 || $gt =~ m{[^ACGT]}msx)) {
 	    $inputOK = 0;
 	}
     }
@@ -278,7 +278,7 @@ sub getSampleNamesIDs {
     my (%samples, @sampleNames);
     for my $i (0..$self->plink->{"individuals"}->size() - 1) {
         my $longName = $self->plink->{"individuals"}->get($i)->{"name"};
-        my ($plate, $well, $id) = split /_/, $longName, 3;
+        my ($plate, $well, $id) = split /_/msx, $longName, 3;
         if ($id) {
             $samples{$longName} = $id;
         } else {
@@ -356,7 +356,7 @@ sub readPlinkCalls {
             if (!$snps{$snp_id}) { next; }
             for my $i (0..$genotypes->size() - 1) {
                 my $call = $genotypes->get($i);
-		if ($call =~ /[N]{2}/) { $call = 0; } 
+		if ($call =~ m{[N]{2}}msx) { $call = 0; }
                 $plinkCalls{$sampleNames[$i]}{$snp_id} = $call;
             }
         }
@@ -405,7 +405,8 @@ sub writeGenotypes {
     my @snps = @{ shift() }; # list of SNPs to output
     my @samples = sort(keys(%genotypes));
     my $outPath = $self->output_dir.'/'.$self->output_names->{'genotypes'};
-    open my $gt, ">", $outPath or die $!;
+    open my $gt, ">", $outPath or
+      die "Failed to open $outPath for writing: $!\n";
     my @heads = qw/SNP sample illumina_call qc_plex_call/;
     print $gt '#'.join("\t", @heads)."\n";
     foreach my $snp (@snps) {
@@ -416,7 +417,7 @@ sub writeGenotypes {
 	    print $gt join("\t", $snp, $sample, $pCall, $sCall), "\n";
 	}
     }
-    close $gt or die $!;
+    close $gt or die "Failed to close $outPath: $!\n";
 }
 
 sub writeIdentity {
@@ -430,7 +431,8 @@ sub writeIdentity {
     my $snpTotal = shift;
     my $minIdent = shift;
     my $outPath = $self->output_dir.'/'.$self->output_names->{'results'};
-    open my $results, ">", $outPath or die $!;
+    open my $results, ">", $outPath or
+      die "Failed to open $outPath for writing: $!\n";
     my $header = join("\t", "#Identity comparison",
 		      "MIN_IDENTITY:$minIdent", 
                       "AVAILABLE_PLEX_SNPS:$snpTotal")."\n";

--- a/src/perl/lib/WTSI/NPG/Genotyping/QC/PlinkIO.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/QC/PlinkIO.pm
@@ -4,7 +4,7 @@
 # June 2012
 
 #
-# Copyright (c) 2012 Genome Research Ltd. All rights reserved.
+# Copyright (C) 2012, 2015 Genome Research Ltd. All rights reserved.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -168,15 +168,18 @@ sub readXPAR {
     my @xpar;
     open my $in, "<", $inPath || croak "Cannot open input $inPath";
     while (<$in>) {
-        if (/^#/) { next; } # comments start with a #
+        if (m{^\#}msx) { next; } # comments start with a #
         chomp;
         my @words = split;
         if (@words!=2) { next; }
         my @coords = ($words[0], $words[1]);
-        if ($words[0] =~ /\D/ || $words[1] =~ /\D/) { next; }
+        if ($words[0] =~ m{\D}msx || $words[1] =~ m{\D}msx) { next; }
         push @xpar, \@coords;
     }
     close $in || croak "Cannot close input $inPath";
+    if (scalar @xpar != 2) {
+      croak "Did not find two pairs of PAR coordinates in $inPath";
+    }
     return @xpar;
 }
 
@@ -190,7 +193,7 @@ sub snpCallsHets {
     my @sampleNames = @$samplesRef;
     for (my $i=0;$i<$total;$i++) { # calls for each sample on current snp
         my $call = $genotypes->get($i);
-        if ($call =~ /[N]{2}/) { 
+        if ($call =~ m{[N]{2}}msx) {
             $noCalls++;
         } else {
             $calls{$sampleNames[$i]} = 1;

--- a/src/perl/lib/WTSI/NPG/Genotyping/QC/QCPlotShared.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/QC/QCPlotShared.pm
@@ -198,11 +198,11 @@ sub parseLabel {
     # silently return undefined values if name not in correct format
     my $label = shift;
     my ($x, $y);
-    if ($label =~ m/^[A-Z][0-9]+$/) { # check name format, eg H10
-        my @chars = split //, $label;
+    if ($label =~ m{^[[:upper:]]\d+$}msx) { # check name format, eg H10
+        my @chars = split //msx, $label;
         $x = ord(uc(shift(@chars))) - 64; # letter -> position in alphabet 
         $y = join('', @chars);
-        $y =~ s/^0+//; # remove leading zeroes from $y
+        $y =~ s/^0+//msx; # remove leading zeroes from $y
     }
     return ($x, $y);
 }
@@ -230,9 +230,9 @@ sub plateLabel {
     my ($plate, $i, $maxLen, $addPrefix) = @_;
     $maxLen ||= 20;
     $addPrefix ||= 1;
-    $plate =~ s/\W+/_/g; # get rid of nonword characters, for LaTeX
+    $plate =~ s/\W+/_/msxg; # get rid of nonword characters, for LaTeX
     my $label;
-    my @chars = split(//, $plate);
+    my @chars = split //msx, $plate;
     my @head = splice(@chars, 0, $maxLen);
     my $name = join('', @head);
     if ($addPrefix) {
@@ -343,7 +343,7 @@ sub readSampleData {
     my $line = 0;
     while (<$in>) {
 	$line++;
-	if (/^#/ || $line <= $startLine) { next; } # comments start with a #
+	if (m{^\#}msx || $line <= $startLine) { next; } # comments start with a #
 	elsif ($stopLine && $line+1 == $stopLine) { last; }
 	my @fields = split;
 	push(@data, \@fields);

--- a/src/perl/lib/WTSI/NPG/Genotyping/QC/QCPlotTests.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/QC/QCPlotTests.pm
@@ -34,7 +34,7 @@ sub createTestDatabase {
 	@names = @$namesRef; 
 	if ($uriStrip) {
 	    for my $i (0..@names-1) {
-		my @fields = split(/:/, $names[$i]);
+		my @fields = split(/:/msx, $names[$i]);
 		my $name = pop(@fields);
 		if ($names{$name}) { croak "Error; sample name $name not unique after removing URI prefixes"; }
 		else { $names[$i] = $name; $names{$name}=1; }  

--- a/src/perl/lib/WTSI/NPG/Genotyping/QC/Reports.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/QC/Reports.pm
@@ -79,7 +79,7 @@ sub getMetricTableHeader {
         $header = $shortNames{$metric}; 
     } else { 
         $header = lc($metric);
-        $header =~ s/_/ /g;
+        $header =~ s/_/ /msxg;
     }
     return $header;
 }
@@ -280,8 +280,8 @@ sub latexTableSingle {
     foreach my $ref (@rows) {
         my @row = @$ref;
         foreach my $item (@row) {
-            $item =~ s/[_]/\\_/g;
-            $item =~ s/%/\\%/g;
+            $item =~ s/[_]/\\_/msxg;
+            $item =~ s/%/\\%/msxg;
             if ($header) { $item = "\\textbf{".$item."}"; } # first row
         }
         $table.=join(" & ", @row)." \\\\ \\hline";
@@ -302,7 +302,7 @@ sub qcNameFromPath {
     if (!($items[-1])) { pop @items; }
     my $qcName;
     foreach my $item (@items) {
-        if ($item =~ m/illuminus|gencall/i) {
+        if ($item =~ m{illuminus|gencall}msxi) {
             $qcName = $item; last;
         }
     }
@@ -319,8 +319,8 @@ sub readGenderThreholds {
         chomp;
         my @words = split();
         my $thresh = pop(@words);
-        if (/^M_max/) { $mMax = $thresh; }
-        if (/^F_min/) { $fMin = $thresh; }
+        if (/^M_max/msx) { $mMax = $thresh; }
+        if (/^F_min/msx) { $fMin = $thresh; }
     }
     close $in || croak "Cannot close input path $inPath";
     return ($mMax, $fMin);
@@ -352,14 +352,14 @@ sub textForDatasets {
     my $qcDir = shift;
     my @headers = @dbInfoHeaders[0..3];
     if ($qcDir) { push(@headers, "directory"); }
-    foreach my $header (@headers) { $header =~ s/_/\\_/g; }
+    foreach my $header (@headers) { $header =~ s/_/\\_/msxg; }
     my @datasetInfo = dbDatasetInfo($dbPath);
     my @text = ();
     push(@text, "\\begin{itemize}\n");
     foreach my $ref (@datasetInfo) {
         my @fields = @$ref;
         if ($qcDir) { push(@fields, $qcDir); }
-	foreach my $field (@fields) { $field =~ s/_/\\_/g; }
+	foreach my $field (@fields) { $field =~ s/_/\\_/msxg; }
 	my $item = "\\item \\textbf{".$headers[0].":} ".$fields[0]."\n";
 	push(@text, $item);
 	push(@text, "\\begin{itemize}\n"); # nested list with details
@@ -464,7 +464,7 @@ sub textForPass {
         $i++;
     }
     my $name =  "\\textbf{".lc($allPlatesName)."}"; 
-    $name =~ s/_/ /g;
+    $name =~ s/_/ /msxg;
     my @fields1 = ($name, $sampleTotal);
     my @fields2 = ($name, );
     foreach my $metric (@metricNames) {

--- a/src/perl/lib/WTSI/NPG/Genotyping/QC/SnpID.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/QC/SnpID.pm
@@ -21,10 +21,10 @@ sub convertFromIlluminaExomeSNP {
     my $id = shift;
     my $pattern = '^exm-';
     my $newID;
-    if ($id =~ /$pattern/) {
-        my @items = split(/$pattern/, $id);
+    if ($id =~ m{$pattern}msx) {
+        my @items = split /$pattern/msx, $id;
         $newID = pop(@items);
-    } else {
+      } else {
         $newID = $id;
     }
     return $newID;
@@ -35,7 +35,7 @@ sub convertToIlluminaExomeSNP {
     my $id = shift;
     my $prefix = 'exm-';
     my $newID;
-    if ($id =~ /^$prefix/) {
+    if ($id =~ m{^$prefix}msx) {
         $newID = $id;
     } else {
         $newID = $prefix.$id;

--- a/src/perl/lib/WTSI/NPG/Genotyping/QC_wip/Check/Identity.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/QC_wip/Check/Identity.pm
@@ -384,7 +384,7 @@ sub _read_production_calls {
 sub _from_illumina_snp_name {
   my ($name) = @_;
 
-  my ($prefix, $body) = $name =~ m{^(exm-)?(.*)};
+  my ($prefix, $body) = $name =~ m{^(exm-)?(.*)}msx;
 
   return $body;
 }

--- a/src/perl/lib/WTSI/NPG/Genotyping/SNP.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/SNP.pm
@@ -63,7 +63,7 @@ has 'snpset' =>
 sub is_gender_marker {
   my ($self) = @_;
 
-  return $self->name =~ m{^GS};
+  return $self->name =~ m{^GS}msx;
 }
 
 =head2 equals
@@ -119,7 +119,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2014, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/SNPSet.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/SNPSet.pm
@@ -245,13 +245,13 @@ sub _parse_snps {
   my $header = $csv->getline($fh);
 
   if ($header and @$header) {
-    unless ($header->[0] =~ m{SNP_NAME}) {
+    unless ($header->[0] =~ m{SNP_NAME}msx) {
       $self->logconfess("SNPSet data file '", $self->str,
                         "' is missing its header");
     }
 
     # Remove comment character from header
-    $header->[0] =~ s/^#(.*)/$1/;
+    $header->[0] =~ s/^\#//msx;
 
     $self->_write_column_names($header);
 
@@ -386,7 +386,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2014, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/AssayResult.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/AssayResult.pm
@@ -135,7 +135,7 @@ sub snp_assayed {
 sub _split_assay_id {
   my ($self) = @_;
 
-  my ($snpset_name, $snp_name) = split /-/, $self->assay_id;
+  my ($snpset_name, $snp_name) = split /-/msx, $self->assay_id;
   $snpset_name ||= '';
   $snp_name    ||= '';
 
@@ -165,7 +165,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2014, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/AssayResultSet.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/AssayResultSet.pm
@@ -138,7 +138,7 @@ sub _parse_assay_results {
     }
 
     # Ignore empty lines
-    if ($str =~ m{^\s*$}) {
+    if ($str =~ m{^\s*$}msx) {
       next;
     }
 
@@ -194,7 +194,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2014 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2014, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/Publisher.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/Publisher.pm
@@ -196,8 +196,8 @@ sub _write_sequenom_csv_file {
   # Transform to the required output headers
   my $fn = sub {
     my $x = shift;
-    $x =~ '^WELL$'                    && return 'WELL_POSITION';
-    $x =~ /^(ASSAY|GENOTYPE|SAMPLE)$/ && return $x . '_ID';
+    $x =~ m{^WELL$}msx                    && return 'WELL_POSITION';
+    $x =~ m{^(ASSAY|GENOTYPE|SAMPLE)$}msx && return $x . '_ID';
     return $x;
   };
 

--- a/src/perl/lib/WTSI/NPG/Genotyping/Types.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Types.pm
@@ -38,17 +38,17 @@ our $VERSION = '';
 
 subtype HsapiensChromosome,
   as Str,
-  where { $_ =~ m{(^[Cc]hr)?[\d+|MT|X|Y]$}s },
+  where { $_ =~ m{(^[Cc]hr)?[\d+|MT|X|Y]$}msx },
   message { "'$_' is not a valid H. sapiens chromosome name" };
 
 subtype HsapiensX,
   as Str,
-  where { $_ =~ m{(^[Cc]hr)?X$}s },
+  where { $_ =~ m{(^[Cc]hr)?X$}msx },
   message { "'$_' is not a valid H. sapiens X chromosome" };
 
 subtype HsapiensY,
   as Str,
-  where { $_ =~ m{(^[Cc]hr)?Y$}s },
+  where { $_ =~ m{(^[Cc]hr)?Y$}msx },
   message { "'$_' is not a valid H. sapiens Y chromosome" };
 
 subtype InfiniumBeadchipBarcode,
@@ -63,7 +63,7 @@ subtype InfiniumBeadchipSection,
 
 subtype DNABase,
   as Str,
-  where { $_ =~ m{^[ACGTNacgtn]$}s },
+  where { $_ =~ m{^[ACGTNacgtn]$}msx },
   message { "'$_' is not a valid DNA base" };
 
 subtype DNAStrand,

--- a/src/perl/lib/WTSI/NPG/Utilities.pm
+++ b/src/perl/lib/WTSI/NPG/Utilities.pm
@@ -80,8 +80,8 @@ sub trim {
   my ($str) = @_;
 
   my $copy = $str;
-  $copy =~ s/^\s*//;
-  $copy =~ s/\s*$//;
+  $copy =~ s/^\s*//msx;
+  $copy =~ s/\s*$//msx;
 
   return $copy;
 }
@@ -103,15 +103,15 @@ sub depad_well {
   if(! defined $str) {
     croak "The str argument was undefined";
   }
-  if ($str !~ m{^[A-Z]\d\d?$}) {
+  if ($str !~ m{^[[:upper:]]\d\d?$}msx) {
     croak "Unexpected well address '$str'. Cannot depad this.";
   }
-  if ($str =~ m{^[A-Z]00$}) {
+  if ($str =~ m{^[[:upper:]]00$}msx) {
     croak "Unexpected well address '$str'. Cannot depad this.";
   }
 
   my $depadded = $str;
-  $depadded =~ s/^([A-Z])0?(\d)$/$1$2/;
+  $depadded =~ s/^([[:upper:]])0?(\d)$/$1$2/msx;
 
   return $depadded;
 }
@@ -136,10 +136,10 @@ sub user_session_log {
   unless (defined $session_name) {
     croak "A defined session_name argument is required\n";
   }
-  unless ($uid =~ /[A-Za-z0-9]+/) {
+  unless ($uid =~ m{[[:alnum:]]+}msx) {
     croak "The uid argument must match [A-Za-z0-9]+\n";
   }
-  unless ($session_name =~ /[A-Za-z0-9]+/) {
+  unless ($session_name =~ m{[[:alnum:]]+}msx) {
     croak "The session_name argument must match [A-Za-z0-9]+\n";
   }
 
@@ -186,7 +186,7 @@ sub collect_files {
           my @elts;
           if (!defined $stop_depth || $current_depth < $stop_depth) {
             # Remove any dirs except . and ..
-            @elts = grep { ! /^\.+$/ } @_;
+            @elts = grep { ! /^[.]+$/msx } @_;
           }
 
           return @elts;
@@ -246,7 +246,7 @@ sub collect_dirs {
 
           my @dirs;
           if (!defined $stop_depth || $current_depth < $stop_depth) {
-            @dirs = grep { -d && ! /^\.+$/ } @_;
+            @dirs = grep { -d && ! /^[.]+$/msx } @_;
           }
 
           return @dirs;
@@ -363,7 +363,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2012 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2012, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Utilities/DelimitedFiles.pm
+++ b/src/perl/lib/WTSI/NPG/Utilities/DelimitedFiles.pm
@@ -31,8 +31,8 @@ sub read_fon {
   my @names;
   while (my $line = <$fh>) {
     chomp($line);
-    $line =~ s/^\s+//;
-    $line =~ s/\s+$//;
+    $line =~ s/^\s+//msx;
+    $line =~ s/\s+$//msx;
     next if $line eq '';
 
     push(@names, $line);
@@ -66,7 +66,10 @@ sub read_column_names {
 
   chomp($line);
 
-  my @names = split /$delimiter/, $line;
+  ## no critic (RegularExpressions::RequireExtendedFormatting)
+  my @names = split /$delimiter/ms, $line;
+  ## critic
+
   $start ||= 0;
   $end ||= scalar @names -1;
 
@@ -162,7 +165,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2012 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2012, 2015 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/t/gender.t
+++ b/src/perl/t/gender.t
@@ -46,12 +46,12 @@ createTestDatabase(\@names, $dbMaster);
 
 foreach my $format (qw/plink json text/) {
     foreach my $jsonOut ((0,1)) {
-        my ($input, $outPath, $outType);
+      my ($input, $outPath, $outType);
 	my $dbfile = "$outDir/genotyping.db";
 	system("cp $dbMaster $dbfile");
         if ($format eq 'json') { $input = "$inputDir/input_xhet.json"; } 
         elsif ($format eq 'text') { $input = "$inputDir/input_xhet.txt"; } 
-        elsif ($format eq 'plink') { $input = $plink; } 
+        elsif ($format eq 'plink') { $input = $plink; }
         my $cmd = "perl $script --run=$runName --input=$input ".
             "--input-format=$format --output-dir=$outDir --dbfile=$dbfile";
         if ($jsonOut) { 
@@ -62,6 +62,7 @@ foreach my $format (qw/plink json text/) {
             $outPath = "$outDir/sample_xhet_gender.txt";
             $outType = 'text';
         }
+
         my $status = system($cmd);
         ## start tests
         is($status, 0, "check_xhet_gender.pl exit status, ".

--- a/src/perl/t/perlcriticrc
+++ b/src/perl/t/perlcriticrc
@@ -88,7 +88,6 @@ file_lexical_variables = :no_restriction
 [-ClassHierarchies::ProhibitAutoloading]
 
 [-BuiltinFunctions::ProhibitStringySplit]
-[-BuiltinFunctions::ProhibitReverseSortBlock]
 
 [-Objects::ProhibitIndirectSyntax]
 

--- a/src/perl/t/perlcriticrc
+++ b/src/perl/t/perlcriticrc
@@ -55,13 +55,6 @@ file_lexical_variables = :no_restriction
 
 # BEGIN temporary reprieve
 
-[-RegularExpressions::RequireLineBoundaryMatching]
-[-RegularExpressions::RequireDotMatchAnything]
-[-RegularExpressions::RequireExtendedFormatting]
-[-RegularExpressions::ProhibitEscapedMetacharacters]
-[-RegularExpressions::ProhibitEnumeratedClasses]
-[-RegularExpressions::ProhibitFixedStringMatches]
-
 [-CodeLayout::ProhibitTrailingWhitespace]
 [-CodeLayout::ProhibitParensWithBuiltins]
 [-CodeLayout::ProhibitHardTabs]
@@ -83,9 +76,7 @@ file_lexical_variables = :no_restriction
 [-ValuesAndExpressions::ProhibitMixedBooleanOperators]
 [-ValuesAndExpressions::ProhibitLongChainsOfMethodCalls]
 [-ValuesAndExpressions::RequireNumberSeparators]
-[-ValuesAndExpressions::ProhibitMismatchedOperators]
 
-[-ErrorHandling::RequireCarping]
 [-ErrorHandling::RequireCheckingReturnValueOfEval]
 
 [-Modules::RequireExplicitPackage]

--- a/src/perl/t/perlcriticrc
+++ b/src/perl/t/perlcriticrc
@@ -87,7 +87,6 @@ file_lexical_variables = :no_restriction
 [-ClassHierarchies::ProhibitExplicitISA]
 [-ClassHierarchies::ProhibitAutoloading]
 
-[-BuiltinFunctions::ProhibitBooleanGrep]
 [-BuiltinFunctions::ProhibitStringySplit]
 [-BuiltinFunctions::ProhibitReverseSortBlock]
 

--- a/src/perl/t/perlcriticrc
+++ b/src/perl/t/perlcriticrc
@@ -77,8 +77,6 @@ file_lexical_variables = :no_restriction
 [-ValuesAndExpressions::ProhibitLongChainsOfMethodCalls]
 [-ValuesAndExpressions::RequireNumberSeparators]
 
-[-ErrorHandling::RequireCheckingReturnValueOfEval]
-
 [-Modules::RequireExplicitPackage]
 
 [-Variables::ProhibitReusedNames]


### PR DESCRIPTION
Critic: RegularExpressions::RequireLineBoundaryMatching
Critic: RegularExpressions::RequireDotMatchAnything
Critic: RegularExpressions::RequireExtendedFormatting
Critic: RegularExpressions::ProhibitEscapedMetacharacters
Critic: RegularExpressions::ProhibitEnumeratedClasses
Critic: RegularExpressions::ProhibitFixedStringMatches
Critic: ErrorHandling::RequireCarping
Critic: ValuesAndExpressions::ProhibitMismatchedOperators
Updated copyright dates. Added some POD.

*Warning* On merging, this will not pass all critic tests. I've omitted changes to the VCF code because that is under heavy change anyway.