### PR TITLE
VCF metadata changes

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -10,6 +10,8 @@ Unreleased
 Added:
 - Store QC plex calls in a VCF file instead of SQLite pipeline database
 - QC check modified to read from VCF instead of database
+- Find Fluidigm/Sequenom results in iRODS and write as VCF, using iRODS
+metadata to construct the VCF header
 
 
 Release 1.11.2: 2015-08-24

--- a/src/perl/bin/check_identity_bed_wip.pl
+++ b/src/perl/bin/check_identity_bed_wip.pl
@@ -4,6 +4,7 @@ use warnings;
 use strict;
 use Carp;
 use Config::IniFiles;
+use File::Slurp qw (read_file);
 use Getopt::Long;
 use JSON;
 use Log::Log4perl;

--- a/src/perl/bin/vcf_from_plink.pl
+++ b/src/perl/bin/vcf_from_plink.pl
@@ -125,11 +125,16 @@ sub run {
     }
 
     # create VCF::Header
+    my %metadata = (
+        reference => [ $manifest, ],
+    );
+
+
     my $contig_lengths = decode_json(read_file($contigs));
     my $header = WTSI::NPG::Genotyping::VCF::Header->new(
         sample_names   => $sample_names,
         contig_lengths => $contig_lengths,
-        reference      => $manifest,
+        metadata       => \%metadata,
     );
 
     # create VCF::VCFDataSet and write object
@@ -187,7 +192,7 @@ sub read_plink_snp_names {
     my @names;
     my $names_raw = read_column($mapPath, 1);
     foreach my $name_raw (@{$names_raw}) {
-        my @id = split /-/, $name_raw;
+        my @id = split /-/msx, $name_raw;
         my $name = pop @id;
         push @names, $name;
     }

--- a/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/AssayResultSet.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/AssayResultSet.pm
@@ -47,25 +47,25 @@ sub size {
   return scalar @{$self->assay_results};
 }
 
-=head2 sample_name
+=head2 canonical_sample_id
 
   Arg [1]    : None
 
-  Example    : $result->sample_name
-  Description: Return the name of the sample analysed. Since Fluidigm
-               results are split into files per sample, there should be
-               only one sample name per file. This method raises an error
-               if it encounters multiple sample names.
+  Example    : $result->canonical_sample_id
+  Description: Return the name (canonical sample identifier) of the sample
+               analysed. Since Fluidigm results are split into files per
+               sample, there should be only one sample name per file. This
+               method raises an error if it encounters multiple sample names.
   Returntype : Str
 
 =cut
 
-# TODO change this to canonical_sample_id for consistency with sequenom?
+# was 'sample_name', now canonical_sample_id for consistency with sequenom
 
-sub sample_name {
+sub canonical_sample_id {
   my ($self) = @_;
 
-  my @names = uniq map { $_->sample_name }
+  my @names = uniq map { $_->canonical_sample_id }
     grep { ! $_->is_empty } @{$self->assay_results};
 
   if (scalar @names > 1) {

--- a/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/Subscriber.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/Subscriber.pm
@@ -3,7 +3,7 @@ package WTSI::NPG::Genotyping::Fluidigm::Subscriber;
 
 use Moose;
 use JSON;
-use List::AllUtils qw(all natatime reduce uniq);
+use List::AllUtils qw(all reduce uniq);
 use Try::Tiny;
 
 use WTSI::NPG::Genotyping::Call;
@@ -19,10 +19,6 @@ our $VERSION = '';
 our $NO_CALL_GENOTYPE = 'NN';
 
 our $CHROMOSOME_JSON_ATTR = 'chromosome_json';
-
-# The largest number of bind variables iRODS supports for 'IN'
-# queries.
-our $BATCH_QUERY_CHUNK_SIZE = 100;
 
 with 'WTSI::DNAP::Utilities::Loggable', 'WTSI::NPG::Annotation',
   'WTSI::NPG::Genotyping::Annotation', 'WTSI::NPG::Genotyping::Subscription';
@@ -52,7 +48,7 @@ has '_plex_name_attr' =>
 
 sub get_assay_resultset {
     my ($self, $sample_identifier, @query_specs) = @_;
-    my $resultsets = $self->get_assay_resultsets
+    my ($resultsets, $vcf_meta) = $self->get_assay_resultsets_and_vcf_metadata
       ([$sample_identifier], @query_specs);
 
     my $num_samples = scalar keys %$resultsets;
@@ -72,86 +68,42 @@ sub get_assay_resultset {
     return shift @resultsets;
 }
 
-=head2 get_assay_resultsets
+=head2 get_assay_resultsets_and_vcf_metadata
 
   Arg [1]    : ArrayRef[Str] sample identifier (dcterms:identifier)
   Arg [n]    : Optional additional query specs as ArrayRefs.
 
   Example    : $sub->get_assay_resultsets(['0123456789'], [study => 12345]);
   Description: Fetch assay result sets by SNP set, sample and other optional
-               criteria.
-  Returntype : HashRef[ArrayRef[
-                 WTSI::NPG::Genotyping::Fluidigm::AssayResultSet]] indexed
+               criteria. Also finds associated VCF metadata.
+  Returntype : - HashRef[ArrayRef[
+                  WTSI::NPG::Genotyping::Fluidigm::AssayResultSet]] indexed
                by sample identifier. Each ArrayRef will usually contain one
                item, but may contain more if multiple assays match the
                search criteria.
+               - HashRef[ArrayRef[Str]] containing VCF metadata.
 
 =cut
 
-sub get_assay_resultsets {
+sub get_assay_resultsets_and_vcf_metadata {
   my ($self, $sample_identifiers, @query_specs) = @_;
 
-  defined $sample_identifiers or
-    $self->logconfess('A defined sample_identifiers argument is required');
-  ref $sample_identifiers eq 'ARRAY' or
-    $self->logconfess('The sample_identifiers argument must be an ArrayRef');
-  _are_unique($sample_identifiers) or
-    $self->logconfess('The sample_identifiers argument contained duplicate ',
-                      'values: [', join(q{, }, @$sample_identifiers), ']');
+  my @obj_paths =
+      $self->_find_object_paths($sample_identifiers, @query_specs);
 
-  my $num_samples = scalar @$sample_identifiers;
-  my $chunk_size = $BATCH_QUERY_CHUNK_SIZE;
-
-  $self->debug("Getting results for $num_samples samples in chunks of ",
-               $chunk_size);
-
-  my @obj_paths;
-  my $iter = natatime $chunk_size, @$sample_identifiers;
-  while (my @ids = $iter->()) {
-    my @id_obj_paths = $self->irods->find_objects_by_meta
-      ($self->data_path,
-       [$self->_plex_name_attr => $self->snpset_name],
-       [$self->dcterms_identifier_attr => \@ids, 'in'], @query_specs);
-    push @obj_paths, @id_obj_paths;
-  }
-
-  my @resultsets = map {
-    WTSI::NPG::Genotyping::Fluidigm::AssayResultSet->new
-        (WTSI::NPG::Genotyping::Fluidigm::AssayDataObject->new
-         ($self->irods, $_));
+  # generate array of AssayDataObjects
+  # use to construct indexed AssayResultSets *and* find metadata
+  my @data_objects = map {
+      WTSI::NPG::Genotyping::Fluidigm::AssayDataObject->new
+            ($self->irods, $_);
   } @obj_paths;
-
-  # Index the results by sample identifier. The identifier is
-  # guaranteed to be present in the metadata because it was in the
-  # search criteria. No assumptions can be made about the order in
-  # which iRODS has returned the results, with respect to the
-  # arguments of the 'IN' clause.
-  my %resultsets_index;
-  foreach my $sample_identifier (@$sample_identifiers) {
-    unless (exists $resultsets_index{$sample_identifier}) {
-      $resultsets_index{$sample_identifier} = [];
-    }
-
-    my @sample_resultsets = grep {
-      $_->data_object->get_avu($self->dcterms_identifier_attr,
-                               $sample_identifier) } @resultsets;
-
-    $self->debug("Found ", scalar @sample_resultsets, " resultsets for ",
-                 "sample '$sample_identifier'");
-
-    # Sanity check that the contents are consistent
-    my @sample_names = map { $_->sample_name } @sample_resultsets;
-    unless (all { $_ eq $sample_names[0] } @sample_names) {
-      $self->logconfess("The resultsets found for sample AVU value ",
-                        "'$sample_identifier': did not all have the same ",
-                        "sample name in their data: [",
-                        join(q{, }, @sample_names), "]");
-    }
-
-    push @{$resultsets_index{$sample_identifier}}, @sample_resultsets;
-  }
-
-  return \%resultsets_index;
+  my @resultsets = map {
+      WTSI::NPG::Genotyping::Fluidigm::AssayResultSet->new($_);
+  } @data_objects;
+  my $resultsets_index =
+      $self->_find_resultsets_index(\@resultsets, $sample_identifiers);
+  my $vcf_meta = $self->_vcf_metadata_from_irods(\@data_objects);
+  return ($resultsets_index, $vcf_meta);
 }
 
 =head2 get_calls
@@ -185,7 +137,7 @@ sub get_calls {
   my @resultsets = @{$assay_resultsets};
   my $num_resultsets = scalar @resultsets;
 
-  my @sample_names = map { $_->sample_name } @resultsets;
+  my @sample_names = map { $_->canonical_sample_id } @resultsets;
   unless (all { $_ eq $sample_names[0] } @sample_names) {
     $self->logconfess('The assay_resultsets must belong to the same sample: [',
                       join(q{, }, @sample_names, ']'));

--- a/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/Subscriber.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/Subscriber.pm
@@ -89,7 +89,7 @@ sub get_assay_resultsets_and_vcf_metadata {
   my ($self, $sample_identifiers, @query_specs) = @_;
 
   my @obj_paths =
-      $self->_find_object_paths($sample_identifiers, @query_specs);
+      $self->find_object_paths($sample_identifiers, @query_specs);
 
   # generate array of AssayDataObjects
   # use to construct indexed AssayResultSets *and* find metadata
@@ -101,8 +101,8 @@ sub get_assay_resultsets_and_vcf_metadata {
       WTSI::NPG::Genotyping::Fluidigm::AssayResultSet->new($_);
   } @data_objects;
   my $resultsets_index =
-      $self->_find_resultsets_index(\@resultsets, $sample_identifiers);
-  my $vcf_meta = $self->_vcf_metadata_from_irods(\@data_objects);
+      $self->find_resultsets_index(\@resultsets, $sample_identifiers);
+  my $vcf_meta = $self->vcf_metadata_from_irods(\@data_objects);
   return ($resultsets_index, $vcf_meta);
 }
 

--- a/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/Subscriber.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/Subscriber.pm
@@ -133,7 +133,7 @@ sub get_assay_resultsets_and_vcf_metadata {
   my ($self, $sample_identifiers, @query_specs) = @_;
 
   my @obj_paths =
-      $self->_find_object_paths($sample_identifiers, @query_specs);
+      $self->find_object_paths($sample_identifiers, @query_specs);
 
   # generate array of AssayDataObjects
   # use to construct indexed AssayResultSets *and* find metadata
@@ -145,8 +145,8 @@ sub get_assay_resultsets_and_vcf_metadata {
       WTSI::NPG::Genotyping::Sequenom::AssayResultSet->new($_);
   } @data_objects;
   my $resultsets_index =
-      $self->_find_resultsets_index(\@resultsets, $sample_identifiers);
-  my $vcf_meta = $self->_vcf_metadata_from_irods(\@data_objects);
+      $self->find_resultsets_index(\@resultsets, $sample_identifiers);
+  my $vcf_meta = $self->vcf_metadata_from_irods(\@data_objects);
   return ($resultsets_index, $vcf_meta);
 }
 

--- a/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/Subscriber.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Sequenom/Subscriber.pm
@@ -112,6 +112,45 @@ sub get_assay_resultsets {
 }
 
 
+=head2 get_assay_resultsets_and_vcf_metadata
+
+  Arg [1]    : ArrayRef[Str] sample identifier (dcterms:identifier)
+  Arg [n]    : Optional additional query specs as ArrayRefs.
+
+  Example    : $sub->get_assay_resultsets(['0123456789'], [study => 12345]);
+  Description: Fetch assay result sets by SNP set, sample and other optional
+               criteria. Also finds associated VCF metadata.
+  Returntype : - HashRef[ArrayRef[
+                  WTSI::NPG::Genotyping::Sequenom::AssayResultSet]] indexed
+               by sample identifier. Each ArrayRef will usually contain one
+               item, but may contain more if multiple assays match the
+               search criteria.
+               - HashRef[ArrayRef[Str]] containing VCF metadata.
+
+=cut
+
+sub get_assay_resultsets_and_vcf_metadata {
+  my ($self, $sample_identifiers, @query_specs) = @_;
+
+  my @obj_paths =
+      $self->_find_object_paths($sample_identifiers, @query_specs);
+
+  # generate array of AssayDataObjects
+  # use to construct indexed AssayResultSets *and* find metadata
+  my @data_objects = map {
+      WTSI::NPG::Genotyping::Sequenom::AssayDataObject->new
+            ($self->irods, $_);
+  } @obj_paths;
+  my @resultsets = map {
+      WTSI::NPG::Genotyping::Sequenom::AssayResultSet->new($_);
+  } @data_objects;
+  my $resultsets_index =
+      $self->_find_resultsets_index(\@resultsets, $sample_identifiers);
+  my $vcf_meta = $self->_vcf_metadata_from_irods(\@data_objects);
+  return ($resultsets_index, $vcf_meta);
+}
+
+
 __PACKAGE__->meta->make_immutable;
 
 no Moose;

--- a/src/perl/lib/WTSI/NPG/Genotyping/Subscription.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Subscription.pm
@@ -143,6 +143,132 @@ sub get_snpset {
 }
 
 
+=head2 find_object_paths
+
+  Arg [1]    : ArrayRef[Str] of sample identifiers
+  Arg [2..]  : Optional specs for iRODS metadata query
+  Example    : my @object_paths = $sub->find_object_paths();
+  Description: Find paths for data objects in iRODS corresponding to the
+               given sample identifiers.
+  Returntype : Array[Str]
+
+=cut
+
+sub find_object_paths {
+    my ($self, $sample_identifiers, @query_specs) = @_;
+
+    defined $sample_identifiers or
+        $self->logconfess('A defined sample_identifiers ',
+                          'argument is required');
+    ref $sample_identifiers eq 'ARRAY' or
+        $self->logconfess('The sample_identifiers argument ',
+                          'must be an ArrayRef');
+    _are_unique($sample_identifiers) or
+        $self->logconfess('The sample_identifiers argument contained ',
+                          'duplicate values: [',
+                          join(q{, }, @$sample_identifiers), ']');
+
+    my $num_samples = scalar @$sample_identifiers;
+    my $chunk_size = $BATCH_QUERY_CHUNK_SIZE;
+
+    $self->debug("Getting results for $num_samples samples in chunks of ",
+                 $chunk_size);
+
+    my @obj_paths;
+    my $iter = natatime $chunk_size, @$sample_identifiers;
+    while (my @ids = $iter->()) {
+        my @id_obj_paths = $self->irods->find_objects_by_meta
+            ($self->data_path,
+             [$self->_plex_name_attr => $self->snpset_name],
+             [$self->dcterms_identifier_attr => \@ids, 'in'], @query_specs);
+        push @obj_paths, @id_obj_paths;
+    }
+    return @obj_paths;
+}
+
+
+=head2 find_resultsets_index
+
+  Arg [1]    : ArrayRef[AssayResultSet] of QC plex AssayResultSets
+  Arg [2]    : ArrayRef[Str] of sample identifiers
+  Example    : my @object_paths = $sub->find_object_paths();
+  Description: Index the results by sample identifier. The identifier is
+               guaranteed to be present in the metadata because it was in the
+               search criteria. No assumptions can be made about the order in
+               which iRODS has returned the results, with respect to the
+               arguments of the 'IN' clause.
+  Returntype : HashRef[ArrayRef[AssayResultSet]]
+
+=cut
+
+sub find_resultsets_index {
+    my ($self, $resultsets, $sample_identifiers) = @_;
+    my %resultsets_index;
+    foreach my $sample_identifier (@$sample_identifiers) {
+        unless (exists $resultsets_index{$sample_identifier}) {
+            $resultsets_index{$sample_identifier} = [];
+        }
+        my @sample_resultsets = grep {
+            $_->data_object->get_avu($self->dcterms_identifier_attr,
+                                     $sample_identifier) } @{$resultsets};
+        $self->debug("Found ", scalar @sample_resultsets, " resultsets for ",
+                     "sample '$sample_identifier'");
+        # Sanity check that the contents are consistent
+        my @sample_names = map { $_->canonical_sample_id } @sample_resultsets;
+        unless (all { $_ eq $sample_names[0] } @sample_names) {
+            $self->logconfess("The resultsets found for sample AVU value ",
+                              "'$sample_identifier'",
+                              ": did not all have the same ",
+                              "sample name in their data: [",
+                              join(q{, }, @sample_names), "]");
+        }
+        push @{$resultsets_index{$sample_identifier}}, @sample_resultsets;
+    }
+    return \%resultsets_index;
+}
+
+
+=head2 vcf_metadata_from_irods
+
+  Arg [1]    : ArrayRef[DataObject] of iRODS DataObjects
+  Example    : my $vcf_meta = $sub->vcf_metadata_from_irods($objects);
+  Description: Retrieve iRODS metadata for the given DataObjects and use to
+               construct VCF metadata.
+  Returntype : HashRef[ArrayRef[Str]]
+
+=cut
+
+sub vcf_metadata_from_irods {
+    my ($self, $data_objects) = @_;
+        my %vcf_meta;
+    my @meta_keys = qw/fluidigm_plex sequenom_plex reference/;
+    my %meta_hash;
+    foreach my $key (@meta_keys) { $meta_hash{$key} = 1; }
+    foreach my $obj (@{$data_objects}) { # check iRODS metadata
+        my @obj_meta = @{$obj->metadata};
+        foreach my $pair (@obj_meta) {
+            my $key = $pair->{'attribute'};
+            my $val = $pair->{'value'};
+            if ($key eq 'fluidigm_plex') {
+                push @{ $vcf_meta{'plex_type'} }, 'fluidigm';
+                push @{ $vcf_meta{'plex_name'} }, $val;
+            } elsif ($key eq 'sequenom_plex') {
+                push @{ $vcf_meta{'plex_type'} }, 'sequenom';
+                push @{ $vcf_meta{'plex_name'} }, $val;
+            }
+            elsif ($meta_hash{$key}) {
+                push @{ $vcf_meta{$key} }, $val;
+            }
+        }
+    }
+    foreach my $key (keys %vcf_meta) {
+        my @values = @{$vcf_meta{$key}};
+        $vcf_meta{$key} = [ uniq @values ];
+    }
+    return \%vcf_meta;
+}
+
+
 sub _are_unique {
   my ($args) = @_;
 
@@ -204,102 +330,6 @@ sub _build_snpset_data_object {
    return WTSI::NPG::iRODS::DataObject->new($self->irods, $path);
 }
 
-sub _find_object_paths {
-    my ($self, $sample_identifiers, @query_specs) = @_;
-
-    defined $sample_identifiers or
-        $self->logconfess('A defined sample_identifiers ',
-                          'argument is required');
-    ref $sample_identifiers eq 'ARRAY' or
-        $self->logconfess('The sample_identifiers argument ',
-                          'must be an ArrayRef');
-    _are_unique($sample_identifiers) or
-        $self->logconfess('The sample_identifiers argument contained ',
-                          'duplicate values: [',
-                          join(q{, }, @$sample_identifiers), ']');
-
-    my $num_samples = scalar @$sample_identifiers;
-    my $chunk_size = $BATCH_QUERY_CHUNK_SIZE;
-
-    $self->debug("Getting results for $num_samples samples in chunks of ",
-                 $chunk_size);
-
-    my @obj_paths;
-    my $iter = natatime $chunk_size, @$sample_identifiers;
-    while (my @ids = $iter->()) {
-        my @id_obj_paths = $self->irods->find_objects_by_meta
-            ($self->data_path,
-             [$self->_plex_name_attr => $self->snpset_name],
-             [$self->dcterms_identifier_attr => \@ids, 'in'], @query_specs);
-        push @obj_paths, @id_obj_paths;
-    }
-    return @obj_paths;
-}
-
-sub _find_resultsets_index {
-    # Index the results by sample identifier. The identifier is
-    # guaranteed to be present in the metadata because it was in the
-    # search criteria. No assumptions can be made about the order in
-    # which iRODS has returned the results, with respect to the
-    # arguments of the 'IN' clause.
-    #
-    # input:
-    # - ArrayRef of AssayResultSets (Sequenom or Fluidigm)
-    # - ArrayRef of sample identifier strings
-    my ($self, $resultsets, $sample_identifiers) = @_;
-    my %resultsets_index;
-    foreach my $sample_identifier (@$sample_identifiers) {
-        unless (exists $resultsets_index{$sample_identifier}) {
-            $resultsets_index{$sample_identifier} = [];
-        }
-        my @sample_resultsets = grep {
-            $_->data_object->get_avu($self->dcterms_identifier_attr,
-                                     $sample_identifier) } @{$resultsets};
-        $self->debug("Found ", scalar @sample_resultsets, " resultsets for ",
-                     "sample '$sample_identifier'");
-        # Sanity check that the contents are consistent
-        my @sample_names = map { $_->canonical_sample_id } @sample_resultsets;
-        unless (all { $_ eq $sample_names[0] } @sample_names) {
-            $self->logconfess("The resultsets found for sample AVU value ",
-                              "'$sample_identifier'",
-                              ": did not all have the same ",
-                              "sample name in their data: [",
-                              join(q{, }, @sample_names), "]");
-        }
-        push @{$resultsets_index{$sample_identifier}}, @sample_resultsets;
-    }
-    return \%resultsets_index;
-}
-
-sub _vcf_metadata_from_irods {
-    my ($self, $data_objects) = @_;
-        my %vcf_meta;
-    my @meta_keys = qw/fluidigm_plex sequenom_plex reference/;
-    my %meta_hash;
-    foreach my $key (@meta_keys) { $meta_hash{$key} = 1; }
-    foreach my $obj (@{$data_objects}) { # check iRODS metadata
-        my @obj_meta = @{$obj->metadata};
-        foreach my $pair (@obj_meta) {
-            my $key = $pair->{'attribute'};
-            my $val = $pair->{'value'};
-            if ($key eq 'fluidigm_plex') {
-                push @{ $vcf_meta{'plex_type'} }, 'fluidigm';
-                push @{ $vcf_meta{'plex_name'} }, $val;
-            } elsif ($key eq 'sequenom_plex') {
-                push @{ $vcf_meta{'plex_type'} }, 'sequenom';
-                push @{ $vcf_meta{'plex_name'} }, $val;
-            }
-            elsif ($meta_hash{$key}) {
-                push @{ $vcf_meta{$key} }, $val;
-            }
-        }
-    }
-    foreach my $key (keys %vcf_meta) {
-        my @values = @{$vcf_meta{$key}};
-        $vcf_meta{$key} = [ uniq @values ];
-    }
-    return \%vcf_meta;
-}
 
 no Moose;
 

--- a/src/perl/lib/WTSI/NPG/Genotyping/Subscription.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Subscription.pm
@@ -4,7 +4,7 @@ package WTSI::NPG::Genotyping::Subscription;
 
 use Moose::Role;
 use JSON;
-use List::AllUtils qw(uniq);
+use List::AllUtils qw(all natatime uniq);
 use WTSI::NPG::Genotyping::Sequenom::AssayDataObject;
 use WTSI::NPG::Genotyping::Sequenom::AssayResultSet;
 use WTSI::NPG::iRODS;
@@ -12,6 +12,10 @@ use WTSI::NPG::iRODS;
 our $VERSION = '';
 
 our $CHROMOSOME_JSON_ATTR = 'chromosome_json';
+
+# The largest number of bind variables iRODS supports for 'IN'
+# queries.
+our $BATCH_QUERY_CHUNK_SIZE = 100;
 
 with 'WTSI::DNAP::Utilities::Loggable';
 
@@ -198,6 +202,103 @@ sub _build_snpset_data_object {
 
    my $path = shift @obj_paths;
    return WTSI::NPG::iRODS::DataObject->new($self->irods, $path);
+}
+
+sub _find_object_paths {
+    my ($self, $sample_identifiers, @query_specs) = @_;
+
+    defined $sample_identifiers or
+        $self->logconfess('A defined sample_identifiers ',
+                          'argument is required');
+    ref $sample_identifiers eq 'ARRAY' or
+        $self->logconfess('The sample_identifiers argument ',
+                          'must be an ArrayRef');
+    _are_unique($sample_identifiers) or
+        $self->logconfess('The sample_identifiers argument contained ',
+                          'duplicate values: [',
+                          join(q{, }, @$sample_identifiers), ']');
+
+    my $num_samples = scalar @$sample_identifiers;
+    my $chunk_size = $BATCH_QUERY_CHUNK_SIZE;
+
+    $self->debug("Getting results for $num_samples samples in chunks of ",
+                 $chunk_size);
+
+    my @obj_paths;
+    my $iter = natatime $chunk_size, @$sample_identifiers;
+    while (my @ids = $iter->()) {
+        my @id_obj_paths = $self->irods->find_objects_by_meta
+            ($self->data_path,
+             [$self->_plex_name_attr => $self->snpset_name],
+             [$self->dcterms_identifier_attr => \@ids, 'in'], @query_specs);
+        push @obj_paths, @id_obj_paths;
+    }
+    return @obj_paths;
+}
+
+sub _find_resultsets_index {
+    # Index the results by sample identifier. The identifier is
+    # guaranteed to be present in the metadata because it was in the
+    # search criteria. No assumptions can be made about the order in
+    # which iRODS has returned the results, with respect to the
+    # arguments of the 'IN' clause.
+    #
+    # input:
+    # - ArrayRef of AssayResultSets (Sequenom or Fluidigm)
+    # - ArrayRef of sample identifier strings
+    my ($self, $resultsets, $sample_identifiers) = @_;
+    my %resultsets_index;
+    foreach my $sample_identifier (@$sample_identifiers) {
+        unless (exists $resultsets_index{$sample_identifier}) {
+            $resultsets_index{$sample_identifier} = [];
+        }
+        my @sample_resultsets = grep {
+            $_->data_object->get_avu($self->dcterms_identifier_attr,
+                                     $sample_identifier) } @{$resultsets};
+        $self->debug("Found ", scalar @sample_resultsets, " resultsets for ",
+                     "sample '$sample_identifier'");
+        # Sanity check that the contents are consistent
+        my @sample_names = map { $_->canonical_sample_id } @sample_resultsets;
+        unless (all { $_ eq $sample_names[0] } @sample_names) {
+            $self->logconfess("The resultsets found for sample AVU value ",
+                              "'$sample_identifier'",
+                              ": did not all have the same ",
+                              "sample name in their data: [",
+                              join(q{, }, @sample_names), "]");
+        }
+        push @{$resultsets_index{$sample_identifier}}, @sample_resultsets;
+    }
+    return \%resultsets_index;
+}
+
+sub _vcf_metadata_from_irods {
+    my ($self, $data_objects) = @_;
+        my %vcf_meta;
+    my @meta_keys = qw/fluidigm_plex sequenom_plex reference/;
+    my %meta_hash;
+    foreach my $key (@meta_keys) { $meta_hash{$key} = 1; }
+    foreach my $obj (@{$data_objects}) { # check iRODS metadata
+        my @obj_meta = @{$obj->metadata};
+        foreach my $pair (@obj_meta) {
+            my $key = $pair->{'attribute'};
+            my $val = $pair->{'value'};
+            if ($key eq 'fluidigm_plex') {
+                push @{ $vcf_meta{'plex_type'} }, 'fluidigm';
+                push @{ $vcf_meta{'plex_name'} }, $val;
+            } elsif ($key eq 'sequenom_plex') {
+                push @{ $vcf_meta{'plex_type'} }, 'sequenom';
+                push @{ $vcf_meta{'plex_name'} }, $val;
+            }
+            elsif ($meta_hash{$key}) {
+                push @{ $vcf_meta{$key} }, $val;
+            }
+        }
+    }
+    foreach my $key (keys %vcf_meta) {
+        my @values = @{$vcf_meta{$key}};
+        $vcf_meta{$key} = [ uniq @values ];
+    }
+    return \%vcf_meta;
 }
 
 no Moose;

--- a/src/perl/lib/WTSI/NPG/Genotyping/VCF/AssayResultParser.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/VCF/AssayResultParser.pm
@@ -8,7 +8,6 @@ use List::AllUtils qw(uniq);
 use Log::Log4perl::Level;
 use Moose;
 
-use WTSI::NPG::iRODS;
 use WTSI::NPG::Genotyping::SNPSet;
 use WTSI::NPG::Genotyping::Call;
 use WTSI::NPG::Genotyping::GenderMarkerCall;
@@ -36,17 +35,7 @@ has 'contig_lengths' => # must be compatible with given snpset
                      'homo sapiens chromosome.',
    );
 
-has 'reference'   =>
-   (is            => 'ro',
-    isa           => 'Str',
-    lazy          => 1,
-    builder       => '_build_reference',
-    documentation => 'String to populate the ##reference field in '.
-                     'a VCF header. Defaults to a comma-separated '.
-                     'list of reference names from the snpset argument.'
-   );
-
-has 'resultsets' =>
+has 'resultsets'  =>
    (is            => 'ro',
     isa           => ArrayRefOfResultSet,
     required      => 1,
@@ -54,10 +43,17 @@ has 'resultsets' =>
                      'names and calls.',
    );
 
-has 'snpset' =>
+has 'snpset'     =>
    (is           => 'ro',
     isa          => 'WTSI::NPG::Genotyping::SNPSet',
-    required => 1,
+    required     => 1,
+   );
+
+has 'metadata' =>
+   (is            => 'ro',
+    isa           => 'HashRef[ArrayRef[Str]]',
+    documentation => 'Additional metadata fields to populate the VCF header',
+    default       => sub { {} },
    );
 
 
@@ -84,7 +80,7 @@ sub get_vcf_dataset {
     my $header = WTSI::NPG::Genotyping::VCF::Header->new(
         sample_names => $samples,
         contig_lengths => $self->contig_lengths,
-	reference => $self->reference,
+	metadata => $self->metadata,
     );
     my @rows;
     foreach my $snp (@{$self->snpset->snps}) {

--- a/src/perl/lib/WTSI/NPG/Genotyping/VCF/Slurper.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/VCF/Slurper.pm
@@ -7,14 +7,17 @@ use Moose;
 use WTSI::NPG::Genotyping::VCF::DataRowParser;
 use WTSI::NPG::Genotyping::VCF::HeaderParser;
 use WTSI::NPG::Genotyping::VCF::VCFDataSet;
+use WTSI::NPG::iRODS;
+use WTSI::NPG::iRODS::DataObject;
 
 with 'WTSI::DNAP::Utilities::Loggable';
 
 has 'snpset'  =>
    (is            => 'ro',
     isa           => 'WTSI::NPG::Genotyping::SNPSet',
-    required      => 1,
+    builder       => '_build_snpset',
     documentation => 'SNPSet containing the variants in the VCF input',
+    lazy          => 1,
    );
 
 has 'input_filehandle' =>
@@ -24,6 +27,21 @@ has 'input_filehandle' =>
     documentation => 'Filehandle for input of VCF data.',
    );
 
+has 'irods'      =>
+  (is            => 'ro',
+   isa           => 'WTSI::NPG::iRODS',
+   required      => 1,
+   default       => sub { return WTSI::NPG::iRODS->new },
+   documentation => 'An iRODS handle');
+
+has 'header' =>
+   (is            => 'ro',
+    isa           => 'WTSI::NPG::Genotyping::VCF::Header',
+    builder       => '_build_header',
+    documentation => 'Object representing the VCF header',
+    lazy          => 1,
+   );
+
 has 'sample_names' =>
    (is             => 'ro',
     isa            => 'ArrayRef[Str]',
@@ -31,7 +49,25 @@ has 'sample_names' =>
                       'override names read from the VCF header.'
    );
 
+has 'snpset_irods_paths' =>
+   (is             => 'ro',
+    isa            => 'HashRef[HashRef[Str]]',
+    documentation  => "Optional hashref containing snpset iRODS paths by ".
+                      "platform name (eg. 'sequenom', 'fluidigm') and ".
+                      "snpset name (eg. 'W30467', 'qc')."
+   );
+
+
 our $VERSION = '';
+
+# can supply a JSON config file instead of SNPSet object
+# uses config to look up snpset from metadata in VCF header
+# alternatively, just use hard-coded defaults
+
+sub BUILD {
+    my ($self) = @_;
+    my $header = $self->header; # ensure header is read first
+}
 
 
 =head2 read_dataset
@@ -47,22 +83,57 @@ our $VERSION = '';
 
 sub read_dataset {
     my ($self) = @_;
-    my %hpArgs = (  input_filehandle => $self->input_filehandle );
-    if ($self->sample_names) {
-        $hpArgs{'sample_names'} = $self->sample_names;
-    }
-    my $headerParser = WTSI::NPG::Genotyping::VCF::HeaderParser->new(
-        %hpArgs);
-    my $header = $headerParser->header();
     my $rowParser = WTSI::NPG::Genotyping::VCF::DataRowParser->new(
         input_filehandle => $self->input_filehandle,
         snpset => $self->snpset,
     );
     my $rows = $rowParser->get_all_remaining_rows();
     return WTSI::NPG::Genotyping::VCF::VCFDataSet->new(
-        header => $header,
+        header => $self->header,
         data   => $rows,
     );
+}
+
+sub _build_header {
+    my ($self) = @_;
+    my %hpArgs = (  input_filehandle => $self->input_filehandle );
+    if ($self->sample_names) {
+        $hpArgs{'sample_names'} = $self->sample_names;
+    }
+    my $headerParser = WTSI::NPG::Genotyping::VCF::HeaderParser->new(
+        %hpArgs);
+    return $headerParser->header();
+}
+
+sub _build_snpset {
+    # use metadata from header to look up snpset location in iRODS
+    my ($self) = @_;
+    unless (defined($self->snpset_irods_paths)) {
+        $self->logcroak("Cannot build snpset from VCF header without a ",
+                        "snpset_paths attribute");
+    }
+    my %metadata = %{$self->header->metadata};
+
+    if (!defined($metadata{'plex_type'}) ||
+            !defined($metadata{'plex_name'})) {
+        $self->logcroak("Cannot build snpset from VCF header without ",
+                        "plex_type and plex_name entries");
+    }
+    my @plex_types =  @{$metadata{'plex_type'}};
+    if (scalar @plex_types > 1) {
+        $self->logcroak("Cannot have more than one plex type in VCF header");
+    }
+    my @plex_names =  @{$metadata{'plex_name'}};
+    if (scalar @plex_names > 1) {
+        $self->logcroak("Cannot have more than one plex name in VCF header");
+    }
+    my $plex_type = shift @plex_types;
+    my $plex_name = shift @plex_names;
+    my $snpset_path = $self->snpset_irods_paths->{$plex_type}->{$plex_name};
+    my $snpset_obj = WTSI::NPG::iRODS::DataObject->new(
+        $self->irods,
+        $snpset_path);
+    return WTSI::NPG::Genotyping::SNPSet->new($snpset_obj);
 }
 
 

--- a/src/perl/t/WTSI/NPG/Genotyping/Fluidigm/AssayResultSetTest.pm
+++ b/src/perl/t/WTSI/NPG/Genotyping/Fluidigm/AssayResultSetTest.pm
@@ -118,8 +118,8 @@ sub assay_addresses : Test(1) {
              'Contains expected assay addresses') or diag explain \@addresses;
 }
 
-sub sample_name : Test(1) {
-  is($resultset->sample_name, 'ABC0123456789', 'Correct sample name');
+sub canonical_sample_id : Test(1) {
+  is($resultset->canonical_sample_id, 'ABC0123456789', 'Correct sample ID');
 }
 
 sub snp_names : Test(1) {

--- a/src/perl/t/vcf/fluidigm.vcf
+++ b/src/perl/t/vcf/fluidigm.vcf
@@ -30,6 +30,8 @@
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##plex_name=qc
+##plex_type=fluidigm
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample001	sample002	sample003	sample004
 1	74941293	rs649058	G	A	.	.	ORIGINAL_STRAND=+	GT:GQ:DP	0/1:40:1	0/1:40:1	0/1:40:1	0/1:40:1
 1	237048500	rs1805087	A	G	.	.	ORIGINAL_STRAND=+	GT:GQ:DP	0/1:40:1	0/1:40:1	0/1:40:1	0/1:40:1

--- a/src/perl/t/vcf/fluidigm_header_1.txt
+++ b/src/perl/t/vcf/fluidigm_header_1.txt
@@ -30,4 +30,6 @@
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##plex_name=qc
+##plex_type=fluidigm
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample001	sample002	sample003	sample004

--- a/src/perl/t/vcf/fluidigm_header_2.txt
+++ b/src/perl/t/vcf/fluidigm_header_2.txt
@@ -30,4 +30,6 @@
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##plex_name=qc
+##plex_type=fluidigm
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	north	south	east	west

--- a/src/perl/t/vcf/sequenom.vcf
+++ b/src/perl/t/vcf/sequenom.vcf
@@ -30,6 +30,8 @@
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Read Depth">
+##plex_name=W30467
+##plex_type=sequenom
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample001	sample002	sample003	sample004
 1	74941293	rs649058	G	A	.	.	ORIGINAL_STRAND=+	GT:GQ:DP	0/0:.:1	0/1:.:1	0/1:.:1	0/1:.:1
 1	169676486	rs1131498	A	G	.	.	ORIGINAL_STRAND=-	GT:GQ:DP	0/0:.:1	0/1:.:1	0/1:.:1	0/1:.:1


### PR DESCRIPTION
- Represent VCF metadata as a HashRef[ArrayRef[Str]]
- Generate VCF metadata using iRODS metadata
- Refactor Sequenom/Fluidigm Subscriber classes by moving shared logic into the Subscription role
