### PR TITLE
Fixed bugs in supplied gender reporting and duplicate processing

### DIFF
--- a/src/perl/lib/WTSI/NPG/Genotyping/QC/Collation.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/QC/Collation.pm
@@ -325,6 +325,11 @@ sub includedSampleCsv {
             else { $metricResult[0] = 'Fail'; }
             if ($metric eq $GENDER_NAME) { # use human-readable gender names
                 $metricResult[2] = $GENDERS[$metricResult[2]];
+                # 'supplied' Plink gender may be -9 or other arbitrary number
+                my $totalCodes = scalar @GENDERS;
+                if ($metricResult[3] < 0 || $metricResult[3] >= $totalCodes){
+                    $metricResult[3] = $totalCodes - 1; # 'not available'
+                }
                 $metricResult[3] = $GENDERS[$metricResult[3]];
             }
             push (@fields, @metricResult);
@@ -694,8 +699,10 @@ sub collate {
     %config = %{decode_json(readFileToString($configPath))};
     %FILENAMES = %{$config{'collation_names'}};
 
-    # 0) reprocess duplicate results for given threshold
-    processDuplicates($inputDir, $thresholdConfig{$DUP_NAME});
+    # 0) reprocess duplicate results for given threshold (if any)
+    if (defined($thresholdConfig{$DUP_NAME})) {
+        processDuplicates($inputDir, $thresholdConfig{$DUP_NAME});
+    }
 
     # 1) find metric values (and write to file if required)
     my $metricResultsRef = findMetricResults($inputDir, \@metricNames);


### PR DESCRIPTION
Fixes two minor bugs:
- If no threshold is supplied for the duplicate metric (eg. for the Illuminus prefilter using call rate only), do not carry out preprocessing of the duplicate results
- Correctly handle arbitrary codes for supplied gender (eg. -9) used in PLINK data
