### PR TITLE
Hotfix for WTSI::NPG::Expression::Publisher when dealing with re-analysed samples.

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -11,6 +11,14 @@ Added:
 - Replace old identity check with new Bayesian version in "main" QC output
 and plots
 
+Release 1.11.6: 2016-02-08
+--------------------------
+
+Fixed:
+- Bug in WTSI::NPG::Expression::Publisher where it used a query against
+the SequenceScape warehouse that was not specific enough to allow it
+to proceed when a sample had been analysed more than once.
+
 Release 1.11.5: 2015-12-15
 --------------------------
 

--- a/src/perl/bin/publish_expression_analysis.pl
+++ b/src/perl/bin/publish_expression_analysis.pl
@@ -172,8 +172,10 @@ sub run {
 
   my $manifest;
   if ($manifest_version eq '1') {
-    $manifest = WTSI::NPG::Expression::ChipLoadingManifestV1->new
-      (file_name => $manifest_path);
+    pod2usage
+      (-msg     => "Invalid --manifest-version, version 1 manifests " .
+                   "are no longer supported\n",
+       -exitval => $EXIT_CLI_VAL);
   }
   elsif ($manifest_version eq '2') {
     $manifest = WTSI::NPG::Expression::ChipLoadingManifestV2->new
@@ -298,8 +300,8 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (C) 2013, 2014, 2015 Genome Research Limited. All Rights
-Reserved.
+Copyright (C) 2013, 2014, 2015, 2016 Genome Research Limited. All
+Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Expression/Publisher.pm
+++ b/src/perl/lib/WTSI/NPG/Expression/Publisher.pm
@@ -108,7 +108,7 @@ sub _publish_files {
   my $sample_id = $resultset->sample_id;
 
   my $ssdb = $self->sequencescape_db;
-  my $ss_sample = $ssdb->find_infinium_gex_sample_by_sanger_id($sample_id);
+  my $ss_sample = $ssdb->find_infinium_gex_sample($plate, $well);
   my $expected_sanger_id = $ss_sample->{sanger_sample_id};
 
   unless ($expected_sanger_id) {
@@ -266,8 +266,8 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (C) 2013, 2014, 2015 Genome Research Limited. All Rights
-Reserved.
+Copyright (C) 2013, 2014, 2015, 2016 Genome Research Limited. All
+Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/lib/WTSI/NPG/Expression/ResultSet.pm
+++ b/src/perl/lib/WTSI/NPG/Expression/ResultSet.pm
@@ -9,8 +9,11 @@ our $VERSION = '';
 with 'WTSI::DNAP::Utilities::Loggable';
 
 has 'sample_id'        => (is => 'ro', isa => 'Str', required => 1);
-has 'plate_id'         => (is => 'ro', isa => 'Str', required => 0);
-has 'well_id'          => (is => 'ro', isa => 'Str', required => 0);
+
+# Set to required because V2 manifests must provide it
+has 'plate_id'         => (is => 'ro', isa => 'Str', required => 1);
+# Set to required because V2 manifests must provide it
+has 'well_id'          => (is => 'ro', isa => 'Str', required => 1);
 
 has 'beadchip'         => (is => 'ro', isa => 'Str', required => 1);
 has 'beadchip_section' => (is => 'ro', isa => 'Str', required => 1);
@@ -55,7 +58,7 @@ Keith James <kdj@sanger.ac.uk>
 
 =head1 COPYRIGHT AND DISCLAIMER
 
-Copyright (c) 2013 Genome Research Limited. All Rights Reserved.
+Copyright (C) 2013, 2016 Genome Research Limited. All Rights Reserved.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the Perl Artistic License or the GNU General

--- a/src/perl/t/WTSI/NPG/Expression/ResultSetTest.pm
+++ b/src/perl/t/WTSI/NPG/Expression/ResultSetTest.pm
@@ -4,12 +4,10 @@ use strict;
 use warnings;
 
 use base qw(Test::Class);
-use Test::More tests => 5;
+use Test::More;
 use Test::Exception;
 
 Log::Log4perl::init('./etc/log4perl_tests.conf');
-
-BEGIN { use_ok('WTSI::NPG::Expression::ResultSet'); }
 
 use WTSI::NPG::Expression::ResultSet;
 
@@ -21,13 +19,35 @@ sub require : Test(1) {
   require_ok('WTSI::NPG::Expression::ResultSet');
 }
 
-sub constructor : Test(3) {
+sub constructor : Test(5) {
   new_ok('WTSI::NPG::Expression::ResultSet',
          [sample_id        => 'sample1',
+          plate_id         => '123456',
+          well_id          => 'A1',
           beadchip         => '012345678901',
           beadchip_section => 'A',
           idat_file        => $idat_path,
           xml_file         => $xml_path]);
+
+  dies_ok {
+    WTSI::NPG::Expression::ResultSet->new
+        (sample_id        => 'sample1',
+         well_id          => 'A1',
+         beadchip         => '012345678901',
+         beadchip_section => 'A',
+         idat_file        => $idat_path,
+         xml_file         => $xml_path);
+  } "Expected to fail when a plate_id is not supplied";
+
+  dies_ok {
+    WTSI::NPG::Expression::ResultSet->new
+        (sample_id        => 'sample1',
+         plate_id         => '123456',
+         beadchip         => '012345678901',
+         beadchip_section => 'A',
+         idat_file        => $idat_path,
+         xml_file         => $xml_path);
+  } "Expected to fail when a well_id is not supplied";
 
   dies_ok {
     WTSI::NPG::Genotyping::Infinium::ResultSet->new
@@ -36,8 +56,7 @@ sub constructor : Test(3) {
          beadchip_section => 'A',
          idat_file        => 'no_such_path',
          xml_file         => $xml_path);
-  }
-    "Expected to fail when the idat file does not exist";
+  } "Expected to fail when the idat file does not exist";
 
   dies_ok {
     WTSI::NPG::Genotyping::Infinium::ResultSet->new
@@ -46,8 +65,7 @@ sub constructor : Test(3) {
          beadchip_section => 'A',
          idat_file        => $idat_path,
          xml_file         => 'no_such_path');
-  }
-    "Expected to fail when the xml file does not exist";
+  } "Expected to fail when the xml file does not exist";
 }
 
 1;


### PR DESCRIPTION
Changed warehouse lookup from using Sanger sample ID to using plate
and well. This avoids returning multiple samples because it is
specific.

The Sanger sample ID is deprecated and was only valuable in V1
manifests. Tightened checks to prevent V1 manifests being used.