### PR TITLE
Fix suffixes - should not contain a dot

### DIFF
--- a/src/perl/bin/publish_infinium_genotypes.pl
+++ b/src/perl/bin/publish_infinium_genotypes.pl
@@ -212,7 +212,7 @@ sub find_files_to_publish {
         if ($file) {
           push @candidate_files, $file;
 
-          my ($basename, $dir, $suffix) = fileparse($file, '.idat', '.gtc');
+          my ($basename, $dir, $suffix) = fileparse($file, 'idat', 'gtc');
           if (not $suffix) {
             $log->logcroak("Failed to parse a file suffix from '$file'");
           }


### PR DESCRIPTION
This presence of the dot is a mistake. The publisher's queries to find existing data do not
return any results because `type = gtc` matches, while `type = .gtc` does not. It therefore
does too much work re-checking files that it could skip, making it inefficient.