### PR TITLE
Change Sequenom reference name from GRCh37_53 to 1000Genomes

### DIFF
--- a/src/perl/etc/ready_qc_sequenom.json
+++ b/src/perl/etc/ready_qc_sequenom.json
@@ -1,7 +1,7 @@
 {
     "data_path": "/seq/sequenom",
     "platform": "sequenom",
-    "reference_name": "Homo_sapiens (GRCh37_53)",
+    "reference_name": "Homo_sapiens (1000Genomes)",
     "reference_path": "/seq/sequenom/multiplexes",
     "snpset_name": "W30467",
     "read_snpset_version": "1.0",


### PR DESCRIPTION
Resolves issue with incompatible chromosome names between 1000Genomes (currently used for Fluidigm) and GRCh37_53.