### PR TITLE
Bugfix for install.sh

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -12,7 +12,7 @@ Added:
 and plots
 
 
-Release 1.12.1: 2016-06-15
+Release 1.13.0: 2016-06-20
 --------------------------
 
 Added:
@@ -30,8 +30,13 @@ messages to STDERR. This in turn requires baton version >= 0.16.4.
 Removed:
 - Script publish_infinium_file_list.pl; superseded by other publish scripts
 
+
+Release 1.12.1: 2016-05-13
+--------------------------
+
 Fixed:
 - Support repeat scans from Infinium database
+
 
 Release 1.12.0: 2016-04-07
 --------------------------

--- a/src/perl/Build.PL
+++ b/src/perl/Build.PL
@@ -16,7 +16,7 @@ my $build = Build->new
    dist_author     => ['Iain Bancarz <ib5@sanger.ac.uk>',
                        'Keith James <kdj@sanger.ac.uk>'],
    dist_abstract   => 'WTSI genotyping data management tools',
-   dist_version    => Build->report_version,,
+   dist_version    => $ENV{'GENOTYPING_VERSION'} || Build->report_version,
    license         => 'gpl',
    configure_requires => {
                           'Module::Build'   => 0.42

--- a/src/ruby/genotyping-workflows/Rakefile
+++ b/src/ruby/genotyping-workflows/Rakefile
@@ -15,13 +15,13 @@ BUILD_DATE = DateTime.now
 # a default of 0.0.0 where the version tag cannot be represented.
 def maybe_git_version(raw_git_version)
   default = '0.0.0'
-  version = raw_git_version.strip
+  version = ENV['GENOTYPING_VERSION'] || raw_git_version.strip
 
   if (/^(\d+\.\d+\.\d+)$/.match(version))
-    $1
+    return version
   else
-    warn "git version string #{version} not in canonical format, defaulting to #{default}"
-    default
+    warn "version string #{version} not in canonical format, defaulting to #{default}"
+    return default
   end
 end
 


### PR DESCRIPTION
- install.sh crashes if the git version string is not compatible with cpanm (eg. contains underscores)
- Significant problem if eg. installying a release candidate for testing
- Allow user to specify a version string in the GENOTYPING_VERSION environment variable 
- Modified Build.PL and Rakefile so that above variable, if present, takes precedence over git version
