### PR TITLE
Ensure that the production iRODS cannot be used in tests with the new clients

### DIFF
--- a/src/perl/t/WTSI/NPG/Test.pm
+++ b/src/perl/t/WTSI/NPG/Test.pm
@@ -11,20 +11,25 @@ use Test::More;
 sub runtests {
   my ($self) = @_;
 
-  my $env_file = $ENV{'WTSI_NPG_iRODS_Test_irodsEnvFile'} || q{};
-  if (not $env_file) {
-    if ($ENV{TEST_AUTHOR}) {
-      die 'Environment variable WTSI_NPG_iRODS_Test_irodsEnvFile was not set';
-    }
-    else {
-      $self->SKIP_CLASS('TEST_AUTHOR environment variable is false');
+  my %env_copy = %ENV;
+
+  # iRODS 3.* and iRODS 4.* have different env vars for configuration
+  foreach my $file (qw(irodsEnvFile IRODS_ENVIRONMENT_FILE)) {
+    my $env_file = $ENV{"WTSI_NPG_iRODS_Test_$file"} || q[];
+
+    # Ensure that the iRODS connection details are a nonsense value if
+    # they are not set explicitly via WTSI_NPG_iRODS_Test_*
+    $env_copy{$file} = $env_file || 'DUMMY_VALUE';
+
+    if (not $env_file) {
+      if ($ENV{TEST_AUTHOR}) {
+        die "Environment variable WTSI_NPG_iRODS_Test_$file was not set";
+      }
+      else {
+        $self->SKIP_CLASS('TEST_AUTHOR environment variable is false');
+      }
     }
   }
-
-  my %env_copy = %ENV;
-  # Ensure that the iRODS connection details are a nonsense value if
-  # they are not set explicitly via WTSI_NPG_iRODS_Test_irodsEnvFile
-  $env_copy{'irodsEnvFile'} = $env_file || 'DUMMY_VALUE';
 
   {
     local %ENV = %env_copy;


### PR DESCRIPTION
Ensure that the production iRODS cannot be used by mistake when using the new v4 iRODS clients.