### PR TITLE
Download cpanm tarball, validate and install

### DIFF
--- a/src/bash/cpanm.sha256
+++ b/src/bash/cpanm.sha256
@@ -1,0 +1,1 @@
+9da50e155df72bce55cb69f51f1dbb4b62d23740fb99f6178bb27f22ebdf8a46  ./App-cpanminus-1.7042.tar.gz


### PR DESCRIPTION
Fixes issue with install.sh exposed by Jenkins tests:
1. Previously, used existing version of cpanm to install the latest version of itself
2. We want to use Perl 5.16.2
3. The existing cpanm installation was compiled with an older Perl verison (5.14)
4. The updated cpanm, and any subsequent modules installed using it, were compiled using 5.14
5. This caused errors when installed modules were not compatible with 5.16.2
6. Solution: Download the cpanm tarball, and install it from scratch using the version of Perl in our environment (which we have set to be 5.16.2 before running install.sh).