### PR TITLE
More robust tempdir management

### DIFF
--- a/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/Collector.pm
+++ b/src/perl/lib/WTSI/NPG/Genotyping/Fluidigm/Collector.pm
@@ -1,9 +1,13 @@
 use utf8;
+use sigtrap qw/die untrapped normal-signals
+               stack-trace any error-signals/;
+# sigtrap ensures tempdir is deleted after control-C or similar
 
 package WTSI::NPG::Genotyping::Fluidigm::Collector;
 
 use DateTime;
-use File::Temp qw/tempdir/;
+use File::Temp;
+use File::Spec;
 use WTSI::NPG::iRODS;
 use WTSI::NPG::Utilities qw/md5sum/;
 
@@ -162,7 +166,8 @@ sub irods_publication_ok {
 
 sub _get_md5_by_address {
     my ($self, $export_file) = @_;
-    my $tmpdir = tempdir("fluidigm_samples_XXXXXX", CLEANUP => 1);
+    my $tmpdir = File::Temp->newdir("fluidigm_samples_XXXXXX",
+                                    dir => File::Spec->tmpdir() );
     my %md5_by_address;
     foreach my $address (@{$export_file->addresses}) {
         my $filename = $export_file->fluidigm_filename($address);
@@ -170,8 +175,9 @@ sub _get_md5_by_address {
         my $records = $export_file->write_assay_result_data($address, $file);
         my $md5 = md5sum($file);
         $md5_by_address{$address} = $md5;
-        $self->debug("Wrote $records records for address $address into ",
-                     "temp file '", $file, "', with md5 '", $md5, "'");
+        $self->debug("Wrote ", $records, " records for address ",
+                     $address, " into temp file ", $file,
+                     ", with md5 ", $md5);
     }
     return %md5_by_address;
 }


### PR DESCRIPTION
- File::Temp->newdir() ensures temporary directory is deleted as soon as it goes out of scope, instead of persisting until script exit. Important as archiving can create large numbers of temporary directories.
- Use the system tempdir (typically /tmp) to avoid cluttering up the working directory
- The sigtrap pragma ensures object destructors are called (thereby removing temp directories), even after Control-C or similar.