### PR TITLE
Changes to tests for iRODS v.4.2

### DIFF
--- a/src/perl/BuildFluidigm.PL
+++ b/src/perl/BuildFluidigm.PL
@@ -4,7 +4,7 @@ use warnings;
 
 # These paths are propagated to @INC in the build script. The 't'
 # directory is added because the Test::Class tests are there.
-use lib qw(. t);
+use lib qw(. t lib);
 
 use WTSI::DNAP::Utilities::Build;
 use BuildFluidigm;

--- a/src/perl/t/WTSI/NPG/Genotyping/Fluidigm/ArchiverTest.pm
+++ b/src/perl/t/WTSI/NPG/Genotyping/Fluidigm/ArchiverTest.pm
@@ -88,7 +88,8 @@ my $pid = $$;
 
 sub make_fixture : Test(setup) {
     # create a Fluidigm resultset and publish to temp iRODS collection
-    my $irods = WTSI::NPG::iRODS->new;
+    my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
+                                      strict_baton_version => 0);
     $irods_tmp_coll = "FluidigmPublisherTest.$pid";
     $irods->add_collection($irods_tmp_coll);
     $irods->add_object("$data_path/$snpset_file",

--- a/src/perl/t/WTSI/NPG/Genotyping/Fluidigm/AssayDataObjectTest.pm
+++ b/src/perl/t/WTSI/NPG/Genotyping/Fluidigm/AssayDataObjectTest.pm
@@ -66,7 +66,8 @@ my $irods_tmp_coll;
 my $pid = $$;
 
 sub make_fixture : Test(setup) {
-  my $irods = WTSI::NPG::iRODS->new;
+  my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
+                                    strict_baton_version => 0);
   $irods_tmp_coll = $irods->add_collection("FluidigmAssayDataObjectTest.$pid");
   $irods->put_collection($data_path, $irods_tmp_coll);
 
@@ -80,6 +81,12 @@ sub make_fixture : Test(setup) {
   $irods->add_object_avu($irods_path, 'study_id',             '10');
   $irods->add_object_avu($irods_path, 'sample_consent',       '1');
   $irods->add_object_avu($irods_path, 'sample_supplier_name', 'zzzzzzzzzz');
+
+
+  # Ideally all iRODS groups that are needed for the test should be created
+  # at this point and then deleted on exit. As it is, the following iRODS
+  # group should be present in test iRODS server before this test is run:
+  # ss_0, ss_10, ss_100.
 
   # Add some ss_ group permissions to be removed
   $irods->set_object_permissions('read', 'ss_10',  $irods_path);

--- a/src/perl/t/WTSI/NPG/Genotyping/Fluidigm/PublisherTest.pm
+++ b/src/perl/t/WTSI/NPG/Genotyping/Fluidigm/PublisherTest.pm
@@ -78,7 +78,8 @@ my $irods_tmp_coll;
 my $pid = $$;
 
 sub make_fixture : Test(setup) {
-  my $irods = WTSI::NPG::iRODS->new;
+  my $irods = WTSI::NPG::iRODS->new(environment          => \%ENV,
+                                    strict_baton_version => 0);
 
   $irods_tmp_coll = "FluidigmPublisherTest.$pid";
   $irods->add_collection($irods_tmp_coll);


### PR DESCRIPTION
A few tests 
t/fluidigm_assay_data_object.t
t/fluidigm_publisher.t
t/fluidigm_archiver.t
were patched so that they can be run against the incoming changes in perl-irods-wrap using iRODS server v.4.2

This pr is for information only.